### PR TITLE
Complete NotionDatabase__mdt and NotionRelation__mdt metadata types

### DIFF
--- a/force-app/main/default/objects/NotionDatabase__mdt/NotionDatabase__mdt.object-meta.xml
+++ b/force-app/main/default/objects/NotionDatabase__mdt/NotionDatabase__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Configuration for Notion databases</description>
+    <label>Notion Database</label>
+    <pluralLabel>Notion Databases</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/NotionDatabase__mdt/fields/DatabaseId__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionDatabase__mdt/fields/DatabaseId__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DatabaseId__c</fullName>
+    <description>Notion database ID</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Database ID</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionDatabase__mdt/fields/DatabaseName__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionDatabase__mdt/fields/DatabaseName__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DatabaseName__c</fullName>
+    <description>Friendly name for the database</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Database Name</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionDatabase__mdt/fields/WorkspaceId__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionDatabase__mdt/fields/WorkspaceId__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>WorkspaceId__c</fullName>
+    <description>Notion workspace ID</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Workspace ID</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionRelation__mdt/NotionRelation__mdt.object-meta.xml
+++ b/force-app/main/default/objects/NotionRelation__mdt/NotionRelation__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Configuration for relationship mappings between Salesforce and Notion objects</description>
+    <label>Notion Relation</label>
+    <pluralLabel>Notion Relations</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/NotionRelation__mdt/fields/ChildObject__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionRelation__mdt/fields/ChildObject__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ChildObject__c</fullName>
+    <description>Reference to child NotionSyncObject__mdt</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Child Object</label>
+    <referenceTo>NotionSyncObject__mdt</referenceTo>
+    <relationshipLabel>Child Relations</relationshipLabel>
+    <relationshipName>ChildRelations</relationshipName>
+    <required>true</required>
+    <type>MetadataRelationship</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionRelation__mdt/fields/NotionRelationPropertyName__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionRelation__mdt/fields/NotionRelationPropertyName__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NotionRelationPropertyName__c</fullName>
+    <description>Notion relation property name</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Notion Relation Property Name</label>
+    <length>80</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionRelation__mdt/fields/ParentObject__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionRelation__mdt/fields/ParentObject__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ParentObject__c</fullName>
+    <description>Reference to parent NotionSyncObject__mdt</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Parent Object</label>
+    <referenceTo>NotionSyncObject__mdt</referenceTo>
+    <relationshipLabel>Parent Relations</relationshipLabel>
+    <relationshipName>ParentRelations</relationshipName>
+    <required>true</required>
+    <type>MetadataRelationship</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NotionRelation__mdt/fields/SalesforceRelationshipField__c.field-meta.xml
+++ b/force-app/main/default/objects/NotionRelation__mdt/fields/SalesforceRelationshipField__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SalesforceRelationshipField__c</fullName>
+    <description>Lookup/Master-detail field name in Salesforce</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Salesforce Relationship Field</label>
+    <length>80</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
This PR implements the missing Custom Metadata Type definitions for NotionDatabase__mdt and NotionRelation__mdt as specified in issue #18.

## Changes
- Created NotionDatabase__mdt with all required fields
- Created NotionRelation__mdt with all required fields including metadata relationships
- All fields follow Salesforce standards and CLAUDE.md specifications

Resolves #18

Generated with [Claude Code](https://claude.ai/code)