### PR TITLE
feat: Add Named Credential for Notion API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,27 @@ cd notion-salesforce-sync
 sfdx force:source:deploy -p force-app/
 ```
 
-3. Configure Named Credentials for Notion API access
+3. Configure Named Credentials for Notion API access:
+
+   a. **Get your Notion API token:**
+   - Go to [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+   - Click "New integration"
+   - Give it a name (e.g., "Salesforce Sync")
+   - Select the workspace you want to connect
+   - Click "Submit"
+   - Copy the "Internal Integration Token" (starts with `secret_`)
+
+   b. **Configure the Named Credential in Salesforce:**
+   - Go to Setup → Security → Named Credentials
+   - Find "Notion API" (deployed with this package)
+   - Click "Edit"
+   - Set the Password field to your Notion API token (the secret_ token from step a)
+   - Save the configuration
+
+   c. **Grant integration access to your Notion databases:**
+   - In Notion, go to each database you want to sync
+   - Click the "..." menu → "Add connections"
+   - Select your integration and click "Confirm"
 
 4. Set up Custom Metadata records for your sync configuration
 

--- a/force-app/main/default/namedCredentials/Notion_API.namedCredential-meta.xml
+++ b/force-app/main/default/namedCredentials/Notion_API.namedCredential-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NamedCredential xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowMergeFieldsInBody>false</allowMergeFieldsInBody>
+    <allowMergeFieldsInHeader>true</allowMergeFieldsInHeader>
+    <endpoint>https://api.notion.com</endpoint>
+    <generateAuthorizationHeader>true</generateAuthorizationHeader>
+    <label>Notion API</label>
+    <principalType>NamedUser</principalType>
+    <protocol>Password</protocol>
+    <username>notion</username>
+</NamedCredential>


### PR DESCRIPTION
**Summary**

This PR implements the Named Credential for Notion API authentication as requested in issue #20.

**Changes Made:**
- Created Named Credential metadata file for Notion API
- Added comprehensive setup documentation to README.md
- Verified NotionApiClient integration is already properly configured

**Testing:**
- Existing test suite covers the authentication flow
- Tests use HTTP mocks to validate API integration

Resolves #20

Generated with [Claude Code](https://claude.ai/code)