### PR TITLE
fix: Create Flow templates with correct XML structure and fix parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ sfdx force:source:deploy -p force-app/
 
 ### Flow Setup
 
+#### Using Flow Templates
+
+This repository includes Flow templates to help you set up synchronization quickly:
+
+- **NotionSync_Template_CreateUpdate.flow-meta.xml**: Template for create/update operations
+- **NotionSync_Template_Delete.flow-meta.xml**: Template for delete operations  
+- **NotionSync_Account_CreateUpdate.flow-meta.xml**: Example Flow for Account object
+
+#### Setting up a New Object Sync
+
+1. **Clone a template Flow**:
+   - For create/update sync: Clone `NotionSync_Template_CreateUpdate`
+   - For delete sync: Clone `NotionSync_Template_Delete`
+
+2. **Update the object reference**:
+   - Change the `<object>` element from `Account` to your desired object API name
+   - Example: `<object>Contact</object>` for Contact records
+
+3. **Update the Object_Type__c value**:
+   - In the `Object_Type__c` field assignment, change the value from `Account` to your object API name
+   - Example: `<stringValue>Contact</stringValue>`
+
+4. **Activate the Flow**:
+   - Change `<status>Draft</status>` to `<status>Active</status>`
+
+#### Manual Flow Setup
+
+If you prefer to create Flows manually:
+
 1. Create a Record-Triggered Flow for each object you want to sync
 2. Configure triggers for Insert, Update, and Delete
 3. Add Create Records action to publish Platform Events

--- a/force-app/main/default/flows/NotionSync_Account_CreateUpdate.flow-meta.xml
+++ b/force-app/main/default/flows/NotionSync_Account_CreateUpdate.flow-meta.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <description>Automatically sync Account records to Notion when created or updated</description>
+    <label>Notion Sync: Account Create/Update</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordTriggers>
+        <name>AccountCreateUpdateTrigger</name>
+        <label>Account Create/Update Trigger</label>
+        <locationX>50</locationX>
+        <locationY>50</locationY>
+        <connector>
+            <targetReference>CreateNotionSyncEvent</targetReference>
+        </connector>
+        <object>Account</object>
+        <schedule>
+            <frequency>Once</frequency>
+            <when>AfterSave</when>
+        </schedule>
+        <triggerType>RecordAfterSave</triggerType>
+    </recordTriggers>
+    <recordCreates>
+        <name>CreateNotionSyncEvent</name>
+        <label>Create Notion Sync Event</label>
+        <locationX>50</locationX>
+        <locationY>200</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>$Record.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Object_Type__c</field>
+            <value>
+                <stringValue>Account</stringValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Operation_Type__c</field>
+            <value>
+                <formulaExpression>IF(ISNEW(), 'CREATE', 'UPDATE')</formulaExpression>
+            </value>
+        </inputAssignments>
+        <object>Notion_Sync_Event__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>AccountCreateUpdateTrigger</targetReference>
+        </connector>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/force-app/main/default/flows/NotionSync_Template_CreateUpdate.flow-meta.xml
+++ b/force-app/main/default/flows/NotionSync_Template_CreateUpdate.flow-meta.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <description>Template Flow for Notion sync on record create/update. To use: 1) Clone this Flow 2) Change the object from 'Account' to your desired object 3) Update the Object_Type__c value to match your object API name</description>
+    <label>Notion Sync Template: Create/Update</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordTriggers>
+        <name>TemplateCreateUpdateTrigger</name>
+        <label>Template Create/Update Trigger</label>
+        <locationX>50</locationX>
+        <locationY>50</locationY>
+        <connector>
+            <targetReference>CreateNotionSyncEvent</targetReference>
+        </connector>
+        <object>Account</object>
+        <schedule>
+            <frequency>Once</frequency>
+            <when>AfterSave</when>
+        </schedule>
+        <triggerType>RecordAfterSave</triggerType>
+    </recordTriggers>
+    <recordCreates>
+        <name>CreateNotionSyncEvent</name>
+        <label>Create Notion Sync Event</label>
+        <locationX>50</locationX>
+        <locationY>200</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>$Record.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Object_Type__c</field>
+            <value>
+                <stringValue>Account</stringValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Operation_Type__c</field>
+            <value>
+                <formulaExpression>IF(ISNEW(), 'CREATE', 'UPDATE')</formulaExpression>
+            </value>
+        </inputAssignments>
+        <object>Notion_Sync_Event__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>TemplateCreateUpdateTrigger</targetReference>
+        </connector>
+    </start>
+    <status>Draft</status>
+</Flow>

--- a/force-app/main/default/flows/NotionSync_Template_Delete.flow-meta.xml
+++ b/force-app/main/default/flows/NotionSync_Template_Delete.flow-meta.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <description>Template Flow for Notion sync on record delete. To use: 1) Clone this Flow 2) Change the object from 'Account' to your desired object 3) Update the Object_Type__c value to match your object API name</description>
+    <label>Notion Sync Template: Delete</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordTriggers>
+        <name>TemplateDeleteTrigger</name>
+        <label>Template Delete Trigger</label>
+        <locationX>50</locationX>
+        <locationY>50</locationY>
+        <connector>
+            <targetReference>CreateNotionSyncEvent</targetReference>
+        </connector>
+        <object>Account</object>
+        <schedule>
+            <frequency>Once</frequency>
+            <when>BeforeDelete</when>
+        </schedule>
+        <triggerType>RecordBeforeDelete</triggerType>
+    </recordTriggers>
+    <recordCreates>
+        <name>CreateNotionSyncEvent</name>
+        <label>Create Notion Sync Event</label>
+        <locationX>50</locationX>
+        <locationY>200</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>$Record.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Object_Type__c</field>
+            <value>
+                <stringValue>Account</stringValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Operation_Type__c</field>
+            <value>
+                <stringValue>DELETE</stringValue>
+            </value>
+        </inputAssignments>
+        <object>Notion_Sync_Event__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>TemplateDeleteTrigger</targetReference>
+        </connector>
+    </start>
+    <status>Draft</status>
+</Flow>


### PR DESCRIPTION
Fixes the Flow template XML parsing errors described in issue #31.

## Changes Made:

- Created Flow templates with proper XML structure
- Fixed formulaValue XML structure using proper `<formulaExpression>` element
- Replaced REPLACE_WITH_OBJECT_API_NAME with 'Account' as default object
- Added comprehensive Flow setup documentation to README.md
- Set template flows to Draft status for safe deployment

## Files Added:

- NotionSync_Account_CreateUpdate.flow-meta.xml
- NotionSync_Template_CreateUpdate.flow-meta.xml
- NotionSync_Template_Delete.flow-meta.xml

Fixes #31

Generated with [Claude Code](https://claude.ai/code)