### PR TITLE
feat: Add manual CI trigger via 'run-ci' label on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, labeled ]
   workflow_dispatch:
     inputs:
       ref:
@@ -15,10 +16,19 @@ on:
 jobs:
   scratch-org-test:
     runs-on: ubuntu-latest
+    # Run on push to main, or on PR when it's opened/synchronized/reopened, or when 'run-ci' label is added
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && 
+       (github.event.action == 'opened' || 
+        github.event.action == 'synchronize' || 
+        github.event.action == 'reopened' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-ci')))
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.ref || github.event.pull_request.head.sha || github.ref }}
       
       - name: Install Salesforce CLI
         run: |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ sf org display -o your-devhub-alias --verbose --json
 ```
 Look for the `sfdxAuthUrl` field in the output.
 
+## CI/CD
+
+### Continuous Integration
+
+This project uses GitHub Actions for automated testing:
+
+- **Automatic CI**: Runs on all pushes to `main` and on all pull requests
+- **Manual CI Trigger**: Add the `run-ci` label to a PR to manually trigger CI
+- **Direct Workflow Execution**: Use the Actions tab to run CI on any branch
+
+The CI workflow:
+1. Creates a temporary Salesforce scratch org
+2. Deploys all metadata
+3. Runs all Apex tests with code coverage
+4. Automatically cleans up the scratch org
+
+### PR Labels
+
+- `run-ci`: Manually triggers the CI workflow on a pull request
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

This PR adds the ability to manually trigger the CI workflow on pull requests by adding a `run-ci` label. This provides more control over when CI runs, which is useful for:

- Re-running CI after infrastructure issues
- Testing specific PRs without pushing new commits
- Manual validation of changes when needed

## Changes

- **GitHub Actions Workflow**: Modified `.github/workflows/ci.yml` to trigger on `labeled` events when the `run-ci` label is added
- **Documentation**: Updated `README.md` with comprehensive CI/CD documentation including:
  - Manual CI trigger instructions
  - PR labels reference
  - CI workflow explanation

## Usage

To manually trigger CI on a pull request:
1. Add the `run-ci` label to the PR
2. The CI workflow will automatically start
3. Remove the label after CI completes (optional)

## Technical Details

The workflow now triggers on:
- Push to `main` branch
- PR opened/synchronized/reopened  
- PR labeled with `run-ci`
- Manual workflow dispatch