### PR TITLE
feat: Add tabbed UI to separate System Settings from Configurations

### DIFF
--- a/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
+++ b/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
@@ -46,41 +46,54 @@
             <div class="slds-p-horizontal_medium">
                 <!-- Current Configurations View (Default) -->
                 <template if:false={selectedObject}>
-                    <div class="slds-p-around_medium">
-                        <!-- Header with New Button -->
-                        <div class="slds-grid slds-grid_align-spread slds-m-bottom_medium">
-                            <div class="slds-col">
-                                <h2 class="slds-text-heading_medium">Sync Configurations</h2>
+                    <!-- Tab Set -->
+                    <lightning-tabset variant="standard" active-tab-value={activeTab}>
+                        <!-- Configurations Tab -->
+                        <lightning-tab label="Configurations" value="configurations">
+                            <div class="slds-p-around_medium">
+                                <!-- Header with New Button -->
+                                <div class="slds-grid slds-grid_align-spread slds-m-bottom_medium">
+                                    <div class="slds-col">
+                                        <h2 class="slds-text-heading_medium">Sync Configurations</h2>
+                                    </div>
+                                    <div class="slds-col_bump-left">
+                                        <lightning-button
+                                            label="New Sync Configuration"
+                                            variant="brand"
+                                            icon-name="utility:add"
+                                            onclick={handleNewConfiguration}
+                                        ></lightning-button>
+                                    </div>
+                                </div>
+                                
+                                <!-- Summary Component -->
+                                <c-notion-sync-summary
+                                    oneditconfiguration={handleEditConfiguration}
+                                ></c-notion-sync-summary>
                             </div>
-                            <div class="slds-col_bump-left">
-                                <lightning-button
-                                    label="New Sync Configuration"
-                                    variant="brand"
-                                    icon-name="utility:add"
-                                    onclick={handleNewConfiguration}
-                                ></lightning-button>
-                            </div>
-                        </div>
+                        </lightning-tab>
                         
-                        <!-- System Settings Section -->
-                        <div class="slds-box slds-m-bottom_medium">
-                            <h3 class="slds-text-heading_small slds-m-bottom_small">System Settings</h3>
-                            <div class="slds-form slds-form_horizontal">
-                                <lightning-input
-                                    type="checkbox"
-                                    label="Enable Sync Logging"
-                                    checked={enableSyncLogging}
-                                    onchange={handleEnableSyncLoggingChange}
-                                    field-level-help="When enabled, all sync operations will be logged to the Notion Sync Log object. Disabled by default for performance."
-                                ></lightning-input>
+                        <!-- Settings Tab -->
+                        <lightning-tab label="Settings" value="settings">
+                            <div class="slds-p-around_medium">
+                                <h2 class="slds-text-heading_medium slds-m-bottom_medium">System Settings</h2>
+                                
+                                <!-- System Settings Section -->
+                                <div class="slds-box">
+                                    <h3 class="slds-text-heading_small slds-m-bottom_small">Logging</h3>
+                                    <div class="slds-form slds-form_horizontal">
+                                        <lightning-input
+                                            type="checkbox"
+                                            label="Enable Sync Logging"
+                                            checked={enableSyncLogging}
+                                            onchange={handleEnableSyncLoggingChange}
+                                            field-level-help="When enabled, all sync operations will be logged to the Notion Sync Log object. Disabled by default for performance."
+                                        ></lightning-input>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                        
-                        <!-- Summary Component -->
-                        <c-notion-sync-summary
-                            oneditconfiguration={handleEditConfiguration}
-                        ></c-notion-sync-summary>
-                    </div>
+                        </lightning-tab>
+                    </lightning-tabset>
                 </template>
 
                 <!-- Object Configuration View -->

--- a/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.js
+++ b/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.js
@@ -24,6 +24,7 @@ export default class NotionSyncAdmin extends LightningElement {
     @track showDatabaseBrowser = false;
     @track showFieldMapping = false;
     @track showRelationshipConfig = false;
+    @track activeTab = 'configurations';
 
     connectedCallback() {
         this.checkPermissionAndLoadData();


### PR DESCRIPTION
## Summary
- Added lightning-tabset with two tabs to the Notion Sync Admin UI
- Moved System Settings to a dedicated "Settings" tab
- Kept Sync Configurations in the "Configurations" tab

## Changes
- Modified `notionSyncAdmin.html` to add tab structure
- Added `activeTab` property to `notionSyncAdmin.js` to track current tab
- No functional changes to the settings or configuration logic

## Test plan
- [x] Verified tabs render correctly in Lightning App Builder
- [x] Tested tab switching works properly
- [x] Confirmed System Settings toggle still functions correctly
- [x] Verified Sync Configurations display and edit functionality unchanged
- [x] All unit tests pass
- [x] Integration tests pass

## Screenshots
The UI now has two clear tabs:
1. **Configurations tab**: Contains the sync configuration table and edit functionality
2. **Settings tab**: Contains the system settings (currently just the sync logging toggle)

This improves the user experience by separating concerns and allowing users to focus on mapping configuration without the distraction of system settings.

🤖 Generated with [Claude Code](https://claude.ai/code)