### PR TITLE
feat: Auto-load .env file in integration test script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,8 @@ URL=$(sf org open --url-only -o notion-sync-scratch)
 
 3. If you have Notion API credentials configured, run integration tests:
    ```bash
-   # If using .env file (recommended)
-   nf run ./scripts/run-integration-tests.sh
-   
-   # Or manually export environment variables
-   export $(cat .env | xargs) && ./scripts/run-integration-tests.sh
+   # The script will automatically load .env file if present
+   ./scripts/run-integration-tests.sh
    ```
 
 Only push your changes after all tests complete successfully.

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -170,14 +170,11 @@ export NOTION_DATABASE_ID_TEST_PARENT='parent-database-id'
 export NOTION_DATABASE_ID_TEST_CHILD='child-database-id'
 ```
 
-#### Using .env File with node-foreman
+#### Using .env File
 
-If you have a `.env` file with your environment variables, you can use `node-foreman` (nf) to automatically load them when running the integration tests:
+The integration test script automatically loads environment variables from a `.env` file if it exists in the project root:
 
 ```bash
-# Install node-foreman if not already installed
-npm install -g foreman
-
 # Create .env file with your configuration
 cat > .env << EOF
 NOTION_API_KEY=your-notion-api-key
@@ -188,8 +185,8 @@ NOTION_TEST_PARENT_DB=parent-database-id
 NOTION_TEST_CHILD_DB=child-database-id
 EOF
 
-# Run integration tests with environment variables loaded from .env
-nf run ./scripts/run-integration-tests.sh
+# Run integration tests (automatically loads .env)
+./scripts/run-integration-tests.sh
 ```
 
 This approach is particularly useful for:

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -8,6 +8,16 @@ set -e  # Exit on error
 echo "=== Notion Integration Test Runner ==="
 echo
 
+# Load .env file if it exists
+if [ -f ".env" ]; then
+    echo "Loading environment variables from .env file..."
+    set -a  # Mark all new variables for export
+    source .env
+    set +a  # Turn off automatic export
+    echo "Environment variables loaded from .env"
+    echo
+fi
+
 # Check required environment variables
 echo "Checking environment variables..."
 


### PR DESCRIPTION
## Summary
- Modified `run-integration-tests.sh` to automatically load environment variables from `.env` file if present
- Removed node-foreman dependency from documentation
- Simplified integration test execution process for better developer experience

## Changes
1. **Integration Test Script**: Added automatic `.env` file loading at the beginning of the script
2. **Documentation Updates**: 
   - Updated `CLAUDE.md` to show simplified command
   - Updated `docs/INTEGRATION_TESTING.md` to remove node-foreman installation and usage

## Test plan
- [ ] Create a `.env` file with test credentials
- [ ] Run `./scripts/run-integration-tests.sh` without exporting environment variables
- [ ] Verify that environment variables are loaded from `.env` file
- [ ] Verify integration tests run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)