### PR TITLE
feat: Standardize scratch org setup with automated script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,16 +44,53 @@ This is a Salesforce-to-Notion synchronization tool that runs entirely within Sa
 
 ## Development Commands
 
-### Scratch Org Setup (Initial or when expired)
-- `sf org create scratch -f config/project-scratch-def.json -a my-scratch` - Create scratch org
-- `sf project deploy start --source-dir force-app` - Deploy all metadata to scratch org
-- `sf org assign permset --name Notion_Integration_User` - Assign integration permission set for API access
-- `sf org assign permset --name Notion_Sync_Admin` - Assign admin permission set to access Notion Sync Admin UI
-- `sf org delete scratch -o my-scratch -p` - Delete scratch org (when done)
+### Scratch Org Setup - Automated (Recommended)
+Use the provided setup script for consistent scratch org initialization:
+
+```bash
+# Create and setup a new scratch org with all configurations
+./scripts/setup-scratch-org.sh
+
+# Or specify a custom org alias
+./scripts/setup-scratch-org.sh my-custom-alias
+```
+
+The setup script automatically:
+1. Creates a new scratch org with 30-day expiration
+2. Deploys all metadata (including integration test objects)
+3. Assigns all required permission sets:
+   - `Notion_Integration_User` - API access permissions
+   - `Notion_Sync_Admin` - Admin UI access
+   - `Notion_Integration_Test_User` - Test object permissions
+4. Generates a password for UI testing
+5. Provides next steps and useful commands
+
+### Scratch Org Setup - Manual (if needed)
+If you prefer manual setup or need to customize the process:
+
+```bash
+# Create scratch org
+sf org create scratch -f config/project-scratch-def.json -a notion-sync-scratch -d -y 7
+
+# Deploy all metadata (including integration folder)
+sf project deploy start --source-dir force-app -o notion-sync-scratch
+
+# Assign ALL required permission sets
+sf org assign permset --name Notion_Integration_User -o notion-sync-scratch
+sf org assign permset --name Notion_Sync_Admin -o notion-sync-scratch
+sf org assign permset --name Notion_Integration_Test_User -o notion-sync-scratch
+
+# Generate password (for UI testing)
+sf org generate password -o notion-sync-scratch
+
+# Open the org
+sf org open -o notion-sync-scratch -p /lightning/n/Notion_Sync_Admin
+```
 
 ### Daily Development Commands
 - `sf project deploy start --source-dir force-app` - Deploy to Salesforce org
 - `sf apex test run --code-coverage --result-format human` - Run all Apex tests
+- `sf org delete scratch -o notion-sync-scratch -p` - Delete scratch org (when done)
 
 ### UI Testing with Playwright MCP
 When testing the UI in Claude, use the Playwright MCP browser control tool:

--- a/docs/SCRATCH_ORG_SETUP.md
+++ b/docs/SCRATCH_ORG_SETUP.md
@@ -1,0 +1,124 @@
+# Scratch Org Setup Guide
+
+This guide explains how to properly set up a scratch org for Notion Salesforce Sync development.
+
+## Quick Start - Automated Setup
+
+The easiest way to set up a scratch org is using the provided setup script:
+
+```bash
+# Default setup (creates org with alias 'notion-sync-scratch')
+./scripts/setup-scratch-org.sh
+
+# Custom alias
+./scripts/setup-scratch-org.sh my-org-alias
+```
+
+## What the Setup Script Does
+
+The setup script (`scripts/setup-scratch-org.sh`) performs the following steps:
+
+1. **Creates a Scratch Org**
+   - 30-day expiration
+   - Sets as default org
+   - Uses configuration from `config/project-scratch-def.json`
+
+2. **Deploys All Metadata**
+   - Deploys both `force-app/main` and `force-app/integration` folders
+   - Includes test objects (Test_Parent_Object__c, Test_Child_Object__c)
+
+3. **Assigns Permission Sets**
+   - `Notion_Integration_User` - Required for API access
+   - `Notion_Sync_Admin` - Required for admin UI access
+   - `Notion_Integration_Test_User` - Required for test object access
+
+4. **Generates Password**
+   - Creates a password for the scratch org user
+   - Useful for UI testing with tools like Playwright
+
+## Manual Setup
+
+If you need to set up the org manually or customize the process:
+
+```bash
+# 1. Create scratch org
+sf org create scratch -f config/project-scratch-def.json -a notion-sync-scratch -d -y 30
+
+# 2. Deploy metadata
+sf project deploy start --source-dir force-app -o notion-sync-scratch
+
+# 3. Assign permission sets
+sf org assign permset --name Notion_Integration_User -o notion-sync-scratch
+sf org assign permset --name Notion_Sync_Admin -o notion-sync-scratch
+sf org assign permset --name Notion_Integration_Test_User -o notion-sync-scratch
+
+# 4. Generate password
+sf org generate password -o notion-sync-scratch
+
+# 5. Open the org
+sf org open -o notion-sync-scratch -p /lightning/n/Notion_Sync_Admin
+```
+
+## Important Notes
+
+### Permission Sets
+
+There are three permission sets that need to be assigned:
+
+1. **Notion_Integration_User** (in `force-app/main`)
+   - Grants API access permissions
+   - Required for the sync functionality to work
+
+2. **Notion_Sync_Admin** (in `force-app/main`)
+   - Grants access to the Notion Sync Admin UI
+   - Required to configure sync settings
+
+3. **Notion_Integration_Test_User** (in `force-app/integration`)
+   - Grants access to test objects and their fields
+   - Required to see field metadata for Test_Parent_Object__c and Test_Child_Object__c
+   - Without this, custom fields will show as "Unknown" type in the UI
+
+### Test Objects
+
+The integration folder contains test objects used for integration testing:
+- `Test_Parent_Object__c` - Parent object with custom fields
+- `Test_Child_Object__c` - Child object with lookup relationships
+
+These objects are only deployed when you deploy the entire `force-app` directory.
+
+## Troubleshooting
+
+### Fields Show as "Unknown" Type
+
+If custom fields for test objects show as "Unknown" type in the Notion Sync Admin UI:
+1. Ensure you've assigned the `Notion_Integration_Test_User` permission set
+2. Refresh the browser page after assignment
+
+### Permission Errors
+
+If you see "You do not have permission to access Notion Sync Admin features":
+1. Ensure you've assigned the `Notion_Sync_Admin` permission set
+2. Log out and log back in if necessary
+
+### Deployment Failures
+
+If deployment fails:
+1. Check that your Dev Hub is enabled
+2. Ensure you're authenticated: `sf org list`
+3. Check the deployment status: `sf project deploy report`
+
+## Useful Commands
+
+```bash
+# View org details (including password)
+sf org display -o notion-sync-scratch
+
+# Get org URL for UI testing
+sf org open --url-only -o notion-sync-scratch
+
+# Open specific page
+sf org open -o notion-sync-scratch -p /lightning/n/Notion_Sync_Admin
+
+# Delete scratch org when done
+sf org delete scratch -o notion-sync-scratch -p
+```

--- a/scripts/setup-scratch-org.sh
+++ b/scripts/setup-scratch-org.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Notion Salesforce Sync - Scratch Org Setup Script
+# This script automates the complete setup of a scratch org for development
+
+set -e  # Exit on error
+
+echo "🚀 Setting up Notion Salesforce Sync scratch org..."
+
+# Check if an org alias is provided, otherwise use default
+ORG_ALIAS=${1:-notion-sync-scratch}
+
+echo "📦 Creating scratch org with alias: $ORG_ALIAS"
+
+# Step 1: Create scratch org
+echo "1️⃣ Creating scratch org..."
+sf org create scratch -f config/project-scratch-def.json -a "$ORG_ALIAS" -d -y 30
+
+# Step 2: Deploy all metadata (including integration folder for test objects)
+echo "2️⃣ Deploying metadata to scratch org..."
+sf project deploy start --source-dir force-app -o "$ORG_ALIAS"
+
+# Step 3: Assign permission sets
+echo "3️⃣ Assigning permission sets..."
+
+# Main permission sets
+echo "   - Assigning Notion Integration User permission set..."
+sf org assign permset --name Notion_Integration_User -o "$ORG_ALIAS"
+
+echo "   - Assigning Notion Sync Admin permission set..."
+sf org assign permset --name Notion_Sync_Admin -o "$ORG_ALIAS"
+
+# Integration test permission set (for test objects)
+echo "   - Assigning Notion Integration Test User permission set..."
+sf org assign permset --name Notion_Integration_Test_User -o "$ORG_ALIAS"
+
+# Step 4: Generate password for the org (useful for UI testing)
+echo "4️⃣ Generating password for scratch org user..."
+sf org generate password -o "$ORG_ALIAS"
+
+# Step 5: Import sample data (optional)
+# echo "5️⃣ Importing sample data..."
+# sf data import tree --plan data/sample-data-plan.json -o "$ORG_ALIAS" 2>/dev/null || echo "   ⚠️  No sample data to import"
+
+# Step 6: Open the org
+echo "✅ Scratch org setup complete!"
+echo ""
+echo "📝 Next steps:"
+echo "   - To open the org: sf org open -o $ORG_ALIAS"
+echo "   - To open Notion Sync Admin: sf org open -o $ORG_ALIAS -p /lightning/n/Notion_Sync_Admin"
+echo "   - To view org details: sf org display -o $ORG_ALIAS"
+echo "   - To delete the org when done: sf org delete scratch -o $ORG_ALIAS -p"
+echo ""
+echo "🔑 For UI testing with Playwright:"
+echo "   - Get org URL: sf org open --url-only -o $ORG_ALIAS"
+echo "   - Get password: sf org display user -o $ORG_ALIAS"
+
+# Optionally open the org
+read -p "Would you like to open the org now? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    sf org open -o "$ORG_ALIAS" -p /lightning/n/Notion_Sync_Admin
+fi


### PR DESCRIPTION
## Summary
- Added automated scratch org setup script to ensure consistent environment configuration
- Fixed issue where test object custom fields showed as "Unknown" type in the UI
- Documented the standardized setup process

## Changes
1. **Created `scripts/setup-scratch-org.sh`**
   - Automates all scratch org setup steps
   - Includes all required permission sets (including `Notion_Integration_Test_User`)
   - Generates password for UI testing
   - Provides clear next steps after setup

2. **Updated `CLAUDE.md`**
   - Added standardized scratch org setup instructions
   - Included both automated (script) and manual setup options
   - Reflects the complete setup process

3. **Created `docs/SCRATCH_ORG_SETUP.md`**
   - Comprehensive guide explaining the setup process
   - Documents all permission sets and their purposes
   - Includes troubleshooting section for common issues

## Root Cause
The issue was that the `Notion_Integration_Test_User` permission set (which grants access to test objects and fields) was not being assigned during scratch org setup. This caused the UI to show "Unknown" for custom field types.

## Test Plan
- [x] Created and tested the setup script with a new scratch org
- [x] Verified all permission sets are assigned correctly
- [x] Confirmed test object fields now display with correct types in the UI
- [ ] CI tests should pass with existing test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)