### PR TITLE
fix: Convert Salesforce ID property field from text input to dropdown

### DIFF
--- a/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
+++ b/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
@@ -169,14 +169,16 @@
                                 </div>
 
                                 <!-- Salesforce ID Property -->
-                                <lightning-input
+                                <lightning-combobox
                                     label="Salesforce ID Property Name"
                                     value={currentConfiguration.salesforceIdPropertyName}
+                                    placeholder="Select a property"
+                                    options={salesforceIdPropertyOptions}
                                     onchange={handleSalesforceIdPropertyChange}
-                                    placeholder="e.g., Salesforce_ID"
                                     required
-                                    field-level-help="Name of the Notion property that will store Salesforce record IDs"
-                                ></lightning-input>
+                                    disabled={isSalesforceIdPropertyDisabled}
+                                    field-level-help="Select the Notion property that will store Salesforce record IDs"
+                                ></lightning-combobox>
                             </div>
 
                             <!-- Field Mappings -->


### PR DESCRIPTION
## Summary

- Converted Salesforce ID property name field from free text input to dropdown selection
- Field now populates with actual Notion database properties for accurate selection
- Prevents configuration errors from invalid property names

## Changes

1. **HTML Template** (`notionSyncAdmin.html`):
   - Changed `<lightning-input>` to `<lightning-combobox>`
   - Added dropdown-specific attributes (options, placeholder, disabled state)

2. **JavaScript Controller** (`notionSyncAdmin.js`):
   - Added `getDatabaseSchema` import to fetch database properties
   - Added `databaseProperties` tracked variable
   - Created `loadDatabaseProperties()` method to fetch properties when database is selected
   - Added `salesforceIdPropertyOptions` computed property to filter text-compatible properties
   - Added `isSalesforceIdPropertyDisabled` computed property for field state
   - Updated event handlers to work with combobox value selection

## Test Results

✅ Creating new sync configuration - dropdown populates after database selection
✅ Editing existing configuration - dropdown shows current value and all options
✅ Only text-compatible properties shown (title, rich_text, url, email, phone_number)
✅ Save button enables when selection changes

## Note

During testing, encountered an unrelated metadata reference error when saving. This is a separate issue with stale relationship metadata IDs and does not affect the Salesforce ID property field functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)