### PR TITLE
Fix relationship count display in Notion Sync Admin UI

### DIFF
--- a/force-app/main/default/classes/NotionAdminController.cls
+++ b/force-app/main/default/classes/NotionAdminController.cls
@@ -153,18 +153,20 @@ public with sharing class NotionAdminController {
                     config.fieldMappings.add(mapping);
                 }
                 
-                // Get relationship mappings
+                // Get relationship mappings where this object is the child (has lookup fields)
                 List<NotionRelation__mdt> relationMappings = [
-                    SELECT Id, ChildObject__c, SalesforceRelationshipField__c, 
-                           NotionRelationPropertyName__c
+                    SELECT Id, ParentObject__c, ParentObject__r.DeveloperName, 
+                           SalesforceRelationshipField__c, NotionRelationPropertyName__c
                     FROM NotionRelation__mdt
-                    WHERE ParentObject__c = :syncObj.Id
+                    WHERE ChildObject__c = :syncObj.Id
                 ];
                 
                 config.relationshipMappings = new List<RelationshipMapping>();
                 for (NotionRelation__mdt relation : relationMappings) {
                     RelationshipMapping mapping = new RelationshipMapping();
-                    mapping.childObject = relation.ChildObject__c;
+                    // Use the developer name from the relationship if available
+                    mapping.parentObject = relation.ParentObject__r != null ? 
+                        relation.ParentObject__r.DeveloperName : relation.ParentObject__c;
                     mapping.salesforceRelationshipField = relation.SalesforceRelationshipField__c;
                     mapping.notionRelationPropertyName = relation.NotionRelationPropertyName__c;
                     mapping.metadataId = relation.Id;
@@ -274,33 +276,23 @@ public with sharing class NotionAdminController {
                     config.fieldMappings.add(mapping);
                 }
                 
-                // Get relationship mappings - Custom Metadata doesn't support OR in WHERE clause
-                // So we need to make two separate queries
-                List<NotionRelation__mdt> parentRelations = [
-                    SELECT Id, DeveloperName, ParentObject__c, ChildObject__c,
-                           SalesforceRelationshipField__c, NotionRelationPropertyName__c
-                    FROM NotionRelation__mdt
-                    WHERE ParentObject__c = :syncObj.Id
-                ];
-                
-                List<NotionRelation__mdt> childRelations = [
-                    SELECT Id, DeveloperName, ParentObject__c, ChildObject__c,
+                // Get relationship mappings where this object has parent relationships
+                // In this model, ChildObject__c is the current object, ParentObject__c is the parent it points to
+                List<NotionRelation__mdt> relations = [
+                    SELECT Id, DeveloperName, ParentObject__c, ParentObject__r.DeveloperName,
+                           ChildObject__c, ChildObject__r.DeveloperName,
                            SalesforceRelationshipField__c, NotionRelationPropertyName__c
                     FROM NotionRelation__mdt
                     WHERE ChildObject__c = :syncObj.Id
                 ];
                 
-                // Combine the results
-                List<NotionRelation__mdt> relations = new List<NotionRelation__mdt>();
-                relations.addAll(parentRelations);
-                relations.addAll(childRelations);
-                
                 for (NotionRelation__mdt relation : relations) {
                     RelationshipMapping mapping = new RelationshipMapping();
-                    mapping.childObject = relation.ChildObject__c;
+                    // The ParentObject__c contains the parent object this field points to
+                    mapping.parentObject = relation.ParentObject__r != null ? 
+                        relation.ParentObject__r.DeveloperName : relation.ParentObject__c;
                     mapping.salesforceRelationshipField = relation.SalesforceRelationshipField__c;
                     mapping.notionRelationPropertyName = relation.NotionRelationPropertyName__c;
-                    mapping.isParent = relation.ParentObject__c == syncObj.Id;
                     mapping.metadataId = relation.Id;
                     config.relationshipMappings.add(mapping);
                 }
@@ -530,10 +522,9 @@ public with sharing class NotionAdminController {
     }
     
     public class RelationshipMapping {
-        @AuraEnabled public String childObject;
+        @AuraEnabled public String parentObject;
         @AuraEnabled public String salesforceRelationshipField;
         @AuraEnabled public String notionRelationPropertyName;
-        @AuraEnabled public Boolean isParent;
         @AuraEnabled public String metadataId;
     }
     

--- a/force-app/main/default/classes/NotionMetadataService.cls
+++ b/force-app/main/default/classes/NotionMetadataService.cls
@@ -106,27 +106,24 @@ public with sharing class NotionMetadataService {
                 relationMetadata.values = new List<MetadataService.CustomMetadataValue>();
                 
                 // Both ParentObject__c and ChildObject__c are required fields
-                // The childObject field contains the metadata ID, we need to get the developer name
-                if (mapping.isParent) {
-                    // For parent relationships: current object is parent, mapping.childObject is child
-                    addMetadataServiceValue(relationMetadata, 'ParentObject__c', objectDeveloperName);
-                    if (String.isNotBlank(mapping.childObject)) {
-                        // The childObject contains the metadata ID, extract the developer name
-                        // For now, use the ID directly as it should be the developer name
-                        addMetadataServiceValue(relationMetadata, 'ChildObject__c', mapping.childObject);
+                // Current object (objectDeveloperName) is the child that has the lookup field
+                // mapping.childObject contains the parent object being referenced
+                addMetadataServiceValue(relationMetadata, 'ChildObject__c', objectDeveloperName);
+                
+                if (String.isNotBlank(mapping.parentObject)) {
+                    // Convert metadata ID to developer name if needed
+                    String parentDeveloperName = getObjectDeveloperName(mapping.parentObject);
+                    if (String.isNotBlank(parentDeveloperName)) {
+                        addMetadataServiceValue(relationMetadata, 'ParentObject__c', parentDeveloperName);
                     } else {
-                        // Fallback if childObject is not provided
-                        addMetadataServiceValue(relationMetadata, 'ChildObject__c', objectDeveloperName);
+                        // Skip this relationship if we can't resolve the parent object
+                        System.debug('Warning: Could not resolve parent object reference: ' + mapping.parentObject);
+                        continue;
                     }
                 } else {
-                    // For child relationships: mapping.childObject is parent, current object is child
-                    if (String.isNotBlank(mapping.childObject)) {
-                        addMetadataServiceValue(relationMetadata, 'ParentObject__c', mapping.childObject);
-                    } else {
-                        // Fallback if childObject is not provided
-                        addMetadataServiceValue(relationMetadata, 'ParentObject__c', objectDeveloperName);
-                    }
-                    addMetadataServiceValue(relationMetadata, 'ChildObject__c', objectDeveloperName);
+                    // Skip if no parent object is specified
+                    System.debug('Warning: No parent object specified for relationship');
+                    continue;
                 }
                 addMetadataServiceValue(relationMetadata, 'SalesforceRelationshipField__c', mapping.salesforceRelationshipField);
                 addMetadataServiceValue(relationMetadata, 'NotionRelationPropertyName__c', mapping.notionRelationPropertyName);
@@ -277,6 +274,60 @@ public with sharing class NotionMetadataService {
         sanitized = sanitized.replaceAll('_+$', '');
         
         return sanitized;
+    }
+    
+    /**
+     * Helper method to convert a metadata ID or developer name to a proper developer name
+     * This handles cases where the childObject field contains either:
+     * - A metadata ID (e.g., 'm02F3000000QE9eIAG')
+     * - A developer name (e.g., 'Account')
+     */
+    private static String getObjectDeveloperName(String objectReference) {
+        if (String.isBlank(objectReference)) {
+            return null;
+        }
+        
+        // Check if it's already a developer name (doesn't start with 'm' followed by ID pattern)
+        if (!objectReference.startsWith('m') || objectReference.length() < 15) {
+            // Assume it's already a developer name
+            return objectReference;
+        }
+        
+        // Try to query the metadata record by ID
+        try {
+            List<NotionSyncObject__mdt> objects = [
+                SELECT DeveloperName
+                FROM NotionSyncObject__mdt
+                WHERE Id = :objectReference
+                LIMIT 1
+            ];
+            
+            if (!objects.isEmpty()) {
+                return objects[0].DeveloperName;
+            }
+        } catch (Exception e) {
+            // If the query fails (e.g., invalid ID), fall through
+            System.debug('Could not query NotionSyncObject__mdt by ID: ' + e.getMessage());
+        }
+        
+        // If we can't find it by ID, check if it might be a developer name anyway
+        try {
+            List<NotionSyncObject__mdt> objects = [
+                SELECT DeveloperName
+                FROM NotionSyncObject__mdt
+                WHERE DeveloperName = :objectReference
+                LIMIT 1
+            ];
+            
+            if (!objects.isEmpty()) {
+                return objects[0].DeveloperName;
+            }
+        } catch (Exception e) {
+            System.debug('Could not query NotionSyncObject__mdt by DeveloperName: ' + e.getMessage());
+        }
+        
+        // If we still can't find it, return null
+        return null;
     }
     
 }

--- a/force-app/main/default/classes/NotionMetadataServiceTest.cls
+++ b/force-app/main/default/classes/NotionMetadataServiceTest.cls
@@ -79,9 +79,9 @@ private class NotionMetadataServiceTest {
         // Add relationship mappings
         config.relationshipMappings = new List<NotionAdminController.RelationshipMapping>();
         NotionAdminController.RelationshipMapping relMapping = new NotionAdminController.RelationshipMapping();
+        relMapping.parentObject = 'Contact';
         relMapping.salesforceRelationshipField = 'ParentId';
         relMapping.notionRelationPropertyName = 'Parent';
-        relMapping.isParent = true;
         config.relationshipMappings.add(relMapping);
         
         Test.startTest();

--- a/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.js
+++ b/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.js
@@ -51,7 +51,7 @@ export default class NotionRelationshipConfig extends LightningElement {
         const newMapping = {
             salesforceRelationshipField: '',
             notionRelationPropertyName: '',
-            isParent: true
+            parentObject: ''
         };
         
         this.relationshipMappings = [...this.relationshipMappings, newMapping];


### PR DESCRIPTION
## Summary
- Fixed incorrect relationship counts displayed in the Notion Sync Admin UI
- Renamed confusing `childObject` field to `parentObject` for better code clarity
- Corrected relationship queries to properly identify parent-child relationships

## Problem
The admin UI was showing incorrect relationship counts because:
1. The field naming was confusing - `childObject` actually contained the parent object reference
2. The queries were not correctly identifying which relationships belonged to each object
3. The UI component was using an outdated `isParent` flag

## Solution
1. **Renamed field for clarity**: Changed `RelationshipMapping.childObject` to `RelationshipMapping.parentObject` throughout the codebase
2. **Fixed relationship queries**: Updated queries in `NotionAdminController` to correctly fetch relationships where the current object is the child (has lookup fields)
3. **Added metadata resolution**: Added `getObjectDeveloperName()` helper method in `NotionMetadataService` to properly resolve metadata IDs to developer names
4. **Updated test and UI**: Updated test class and LWC component to use the new field name

## Changes Made
- `NotionAdminController.cls`: Fixed relationship queries and renamed field references
- `NotionMetadataService.cls`: Added proper parent object resolution and renamed field references
- `NotionMetadataServiceTest.cls`: Updated test to use renamed field
- `notionRelationshipConfig.js`: Removed `isParent` flag and added `parentObject` field

## Test Plan
- [x] Code compiles without errors
- [x] All unit tests pass
- [ ] Deploy to scratch org and verify relationship counts display correctly
- [ ] Test creating new relationship mappings through the UI
- [ ] Verify existing relationship mappings still work

🤖 Generated with [Claude Code](https://claude.ai/code)