### PR TITLE
fix: Update NotionRelation metadata labels for clarity

### DIFF
--- a/force-app/integration/default/customMetadata/NotionRelation.Test_Child_Object_c_Account_c.md-meta.xml
+++ b/force-app/integration/default/customMetadata/NotionRelation.Test_Child_Object_c_Account_c.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account to Test Child Relation</label>
+    <label>Test Child to Account</label>
     <protected>false</protected>
     <values>
         <field>ChildObject__c</field>

--- a/force-app/integration/default/customMetadata/NotionRelation.Test_Child_Object_c_Test_Parent_c.md-meta.xml
+++ b/force-app/integration/default/customMetadata/NotionRelation.Test_Child_Object_c_Test_Parent_c.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Test Parent to Test Child Relation</label>
+    <label>Test Child to Test Parent</label>
     <protected>false</protected>
     <values>
         <field>ChildObject__c</field>


### PR DESCRIPTION
## Summary
- Fixed confusing NotionRelation custom metadata labels
- Changed labels to clearly indicate child-to-parent relationships

## Changes
- Changed 'Account to Test Child Relation' to 'Test Child to Account'
- Changed 'Test Parent to Test Child Relation' to 'Test Child to Test Parent'

## Test Plan
- [x] Deploy metadata to scratch org
- [x] Verify labels are more intuitive in the UI
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)