### PR TITLE
fix: Handle namespace prefix for Named Credential references

### DIFF
--- a/force-app/main/default/classes/NotionApiClient.cls
+++ b/force-app/main/default/classes/NotionApiClient.cls
@@ -1,7 +1,25 @@
 public class NotionApiClient {
     
-    private static final String NAMED_CREDENTIAL = 'callout:Notion_API';
+    private static final String NAMED_CREDENTIAL = 'callout:' + getNamespacedName('Notion_API');
     private static final String API_VERSION = '2022-06-28';
+    
+    /**
+     * Get the properly namespaced name for a Named Credential
+     * This handles both namespaced (managed package) and non-namespaced scenarios
+     */
+    private static String getNamespacedName(String baseName) {
+        // Get the namespace by examining the class name
+        String className = NotionApiClient.class.getName();
+        
+        // If the class name contains a dot, it has a namespace
+        if (className.contains('.')) {
+            String namespace = className.substringBefore('.');
+            return namespace + '__' + baseName;
+        }
+        
+        // No namespace, return the base name as-is
+        return baseName;
+    }
     
     public class NotionApiException extends Exception {}
     

--- a/force-app/main/default/classes/NotionApiClientTest.cls
+++ b/force-app/main/default/classes/NotionApiClientTest.cls
@@ -558,4 +558,58 @@ public class NotionApiClientTest {
             return response;
         }
     }
+    
+    @isTest
+    static void testNamespaceHandling() {
+        // Test that the Named Credential is properly namespaced
+        // This test validates the endpoint URL contains the correct Named Credential reference
+        Test.setMock(HttpCalloutMock.class, new NamespaceValidationMock());
+        
+        Map<String, Object> properties = new Map<String, Object>();
+        properties.put('Name', NotionApiClient.buildTitleProperty('Test Page'));
+        
+        NotionApiClient.NotionPageRequest pageRequest = new NotionApiClient.NotionPageRequest(
+            'test-database-id', 
+            properties
+        );
+        
+        Test.startTest();
+        NotionApiClient.NotionResponse response = NotionApiClient.createPage(pageRequest);
+        Test.stopTest();
+        
+        // The mock validates that the endpoint contains the proper Named Credential format
+        System.assert(response.success, 'Request should succeed with proper Named Credential');
+    }
+    
+    private class NamespaceValidationMock implements HttpCalloutMock {
+        public HttpResponse respond(HttpRequest request) {
+            // Validate that the endpoint starts with 'callout:'
+            System.assert(request.getEndpoint().startsWith('callout:'), 
+                         'Endpoint should use Named Credential syntax');
+            
+            // Check if the endpoint contains namespace prefix (for managed packages)
+            // or just the base name (for unmanaged code)
+            String endpoint = request.getEndpoint();
+            Boolean hasNamespace = endpoint.contains('__Notion_API');
+            Boolean hasBaseName = endpoint.contains(':Notion_API');
+            
+            System.assert(hasNamespace || hasBaseName, 
+                         'Endpoint should contain either namespaced or base Named Credential name');
+            
+            // Return success response
+            HttpResponse response = new HttpResponse();
+            response.setStatusCode(200);
+            response.setHeader('Content-Type', 'application/json');
+            
+            Map<String, Object> responseBody = new Map<String, Object>{
+                'id' => 'test-page-id',
+                'object' => 'page',
+                'created_time' => '2023-01-01T00:00:00.000Z',
+                'last_edited_time' => '2023-01-01T00:00:00.000Z'
+            };
+            
+            response.setBody(JSON.serialize(responseBody));
+            return response;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed Named Credential reference to work correctly in both managed package (with namespace) and unmanaged contexts
- Added dynamic namespace detection that automatically prefixes the Named Credential when running in a namespace

## Problem
The current implementation uses a hardcoded Named Credential reference `'callout:Notion_API'` which fails when the package is installed as a managed package with a namespace (e.g., `notionsync`). In managed packages, the Named Credential needs to be prefixed with the namespace: `'callout:notionsync__Notion_API'`.

## Solution
- Added `getNamespacedName()` method that detects if code is running in a namespace by examining the class name
- Automatically adds namespace prefix when detected (e.g., `notionsync__Notion_API`)
- Works correctly in both scenarios without configuration changes

## Test Plan
- [x] Added unit test `testNamespaceHandling()` to verify endpoint URL format
- [x] Tests pass in scratch org (unmanaged context)
- [ ] CI tests will verify functionality
- [ ] When deployed as managed package, Named Credential will be properly namespaced

🤖 Generated with [Claude Code](https://claude.ai/code)