### PR TITLE
Revert "chore: Bump version to 1.2.0 for namespace support release"

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,9 +4,9 @@
       "path": "force-app/main",
       "default": true,
       "package": "Notion Salesforce Sync",
-      "versionName": "Version 1.2",
-      "versionNumber": "1.2.0.NEXT",
-      "versionDescription": "Added namespace support for Named Credentials"
+      "versionName": "Version 1.0",
+      "versionNumber": "1.0.0.NEXT",
+      "versionDescription": "Salesforce to Notion synchronization tool"
     },
     {
       "path": "force-app/integration",


### PR DESCRIPTION
Reverting the premature version bump. The version should remain at 1.0.0 as the package version was already created without the version number update in the project file.