### PR TITLE
fix: Add namespace support for Metadata API operations in packaged environments

### DIFF
--- a/force-app/main/default/classes/NamespaceUtil.cls
+++ b/force-app/main/default/classes/NamespaceUtil.cls
@@ -1,0 +1,133 @@
+/**
+ * Utility class for handling namespace-aware operations in both packaged and unpackaged environments.
+ * This is essential for 2GP (Second-Generation Package) compatibility.
+ */
+public with sharing class NamespaceUtil {
+    private static String cachedNamespace = null;
+    private static Boolean namespaceDetected = false;
+    
+    /**
+     * Gets the current namespace by examining the class name.
+     * Returns null if no namespace is present.
+     */
+    public static String getNamespace() {
+        if (!namespaceDetected) {
+            String className = NamespaceUtil.class.getName();
+            
+            // If the class name contains a dot, it has a namespace
+            if (className.contains('.')) {
+                cachedNamespace = className.substringBefore('.');
+            } else {
+                cachedNamespace = null;
+            }
+            
+            namespaceDetected = true;
+        }
+        
+        return cachedNamespace;
+    }
+    
+    /**
+     * Prefixes a custom object or custom metadata type name with the namespace if present.
+     * @param apiName The API name without namespace (e.g., 'NotionSyncObject__mdt')
+     * @return The properly namespaced API name
+     */
+    public static String applyNamespace(String apiName) {
+        if (String.isBlank(apiName)) {
+            return apiName;
+        }
+        
+        String namespace = getNamespace();
+        if (String.isNotBlank(namespace)) {
+            // Check if already namespaced
+            if (!apiName.startsWith(namespace + '__')) {
+                return namespace + '__' + apiName;
+            }
+        }
+        
+        return apiName;
+    }
+    
+    /**
+     * Removes the namespace prefix from an API name if present.
+     * @param apiName The API name that might have a namespace
+     * @return The API name without namespace
+     */
+    public static String removeNamespace(String apiName) {
+        if (String.isBlank(apiName)) {
+            return apiName;
+        }
+        
+        String namespace = getNamespace();
+        if (String.isNotBlank(namespace) && apiName.startsWith(namespace + '__')) {
+            return apiName.substring(namespace.length() + 2);
+        }
+        
+        return apiName;
+    }
+    
+    /**
+     * Checks if the current environment has a namespace (is packaged).
+     * @return True if running in a namespaced environment
+     */
+    public static Boolean hasNamespace() {
+        return String.isNotBlank(getNamespace());
+    }
+    
+    /**
+     * Gets the properly namespaced name for a custom metadata type.
+     * @param baseName The base metadata type name (e.g., 'NotionSyncObject')
+     * @return The fully qualified metadata type name with namespace if applicable
+     */
+    public static String getMetadataTypeName(String baseName) {
+        if (String.isBlank(baseName)) {
+            return baseName;
+        }
+        
+        // Remove __mdt suffix if present
+        if (baseName.endsWith('__mdt')) {
+            baseName = baseName.substring(0, baseName.length() - 5);
+        }
+        
+        // Apply namespace and add __mdt suffix
+        return applyNamespace(baseName + '__mdt');
+    }
+    
+    /**
+     * Gets the properly namespaced name for a custom object.
+     * @param baseName The base object name (e.g., 'Notion_Sync_Log')
+     * @return The fully qualified object name with namespace if applicable
+     */
+    public static String getObjectName(String baseName) {
+        if (String.isBlank(baseName)) {
+            return baseName;
+        }
+        
+        // Remove __c suffix if present
+        if (baseName.endsWith('__c')) {
+            baseName = baseName.substring(0, baseName.length() - 3);
+        }
+        
+        // Apply namespace and add __c suffix
+        return applyNamespace(baseName + '__c');
+    }
+    
+    /**
+     * Gets the properly namespaced name for a custom field.
+     * @param baseName The base field name (e.g., 'IsActive')
+     * @return The fully qualified field name with namespace if applicable
+     */
+    public static String getFieldName(String baseName) {
+        if (String.isBlank(baseName)) {
+            return baseName;
+        }
+        
+        // Remove __c suffix if present
+        if (baseName.endsWith('__c')) {
+            baseName = baseName.substring(0, baseName.length() - 3);
+        }
+        
+        // Apply namespace and add __c suffix
+        return applyNamespace(baseName + '__c');
+    }
+}

--- a/force-app/main/default/classes/NamespaceUtil.cls-meta.xml
+++ b/force-app/main/default/classes/NamespaceUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NotionMetadataService.cls
+++ b/force-app/main/default/classes/NotionMetadataService.cls
@@ -19,7 +19,7 @@ public with sharing class NotionMetadataService {
         // Create or update NotionSyncObject__mdt
         String objectDeveloperName = sanitizeDeveloperName(config.objectApiName);
         MetadataService.CustomMetadata objectMetadata = new MetadataService.CustomMetadata();
-        objectMetadata.fullName = 'NotionSyncObject__mdt.' + objectDeveloperName;
+        objectMetadata.fullName = NamespaceUtil.getMetadataTypeName('NotionSyncObject') + '.' + objectDeveloperName;
         objectMetadata.label = config.objectApiName + ' Sync Configuration';
         
         // Set field values
@@ -51,7 +51,7 @@ public with sharing class NotionMetadataService {
             List<String> metadataToDelete = new List<String>();
             for (NotionSyncField__mdt existingField : existingFields) {
                 if (!newFieldKeys.contains(existingField.DeveloperName)) {
-                    metadataToDelete.add('NotionSyncField__mdt.' + existingField.DeveloperName);
+                    metadataToDelete.add(NamespaceUtil.getMetadataTypeName('NotionSyncField') + '.' + existingField.DeveloperName);
                 }
             }
             
@@ -64,7 +64,7 @@ public with sharing class NotionMetadataService {
                 String fieldDeveloperName = objectDeveloperName + '_' + sanitizeDeveloperName(mapping.salesforceFieldApiName);
                 
                 MetadataService.CustomMetadata fieldMetadata = new MetadataService.CustomMetadata();
-                fieldMetadata.fullName = 'NotionSyncField__mdt.' + fieldDeveloperName;
+                fieldMetadata.fullName = NamespaceUtil.getMetadataTypeName('NotionSyncField') + '.' + fieldDeveloperName;
                 fieldMetadata.label = mapping.salesforceFieldApiName + ' → ' + mapping.notionPropertyName;
                 
                 // Set field values
@@ -112,7 +112,7 @@ public with sharing class NotionMetadataService {
             List<String> relationshipsToDelete = new List<String>();
             for (NotionRelation__mdt existingRelation : existingRelations) {
                 if (!newRelationshipKeys.contains(existingRelation.DeveloperName)) {
-                    relationshipsToDelete.add('NotionRelation__mdt.' + existingRelation.DeveloperName);
+                    relationshipsToDelete.add(NamespaceUtil.getMetadataTypeName('NotionRelation') + '.' + existingRelation.DeveloperName);
                 }
             }
             
@@ -139,7 +139,7 @@ public with sharing class NotionMetadataService {
                 }
                 
                 MetadataService.CustomMetadata relationMetadata = new MetadataService.CustomMetadata();
-                relationMetadata.fullName = 'NotionRelation__mdt.' + relationDeveloperName;
+                relationMetadata.fullName = NamespaceUtil.getMetadataTypeName('NotionRelation') + '.' + relationDeveloperName;
                 relationMetadata.label = mapping.salesforceRelationshipField + ' Relation';
                 
                 // Set field values
@@ -207,7 +207,8 @@ public with sharing class NotionMetadataService {
     
     private static void addMetadataServiceValue(MetadataService.CustomMetadata metadata, String field, String value) {
         MetadataService.CustomMetadataValue customField = new MetadataService.CustomMetadataValue();
-        customField.field = field;
+        // Apply namespace to the field name if needed
+        customField.field = NamespaceUtil.getFieldName(field);
         customField.value = value;
         metadata.values.add(customField);
     }
@@ -243,7 +244,7 @@ public with sharing class NotionMetadataService {
         
         // Soft delete: Update the object metadata to set IsDeleted__c = true
         MetadataService.CustomMetadata objectMetadata = new MetadataService.CustomMetadata();
-        objectMetadata.fullName = 'NotionSyncObject__mdt.' + objectDeveloperName;
+        objectMetadata.fullName = NamespaceUtil.getMetadataTypeName('NotionSyncObject') + '.' + objectDeveloperName;
         // Truncate label to ensure it fits within 40 character limit
         String label = objectApiName + ' (Deleted)';
         if (label.length() > 40) {


### PR DESCRIPTION
## Summary
- Created NamespaceUtil class to detect and apply namespace prefixes dynamically
- Updated NotionMetadataService to use namespace-aware metadata type names for MetadataService API calls
- Fixes the "Cannot invoke getEntityInfo()... return value is null" error when saving sync configurations in 2GP packaged environments

## Problem
When using the packaged version of the app (with namespace), saving sync configurations failed with an error because the MetadataService API couldn't find the Custom Metadata Types when referenced without namespace prefixes.

## Solution
The fix adds namespace detection and automatically prefixes metadata type names and field names when making MetadataService API calls. SOQL queries remain unchanged as they handle namespacing automatically.

## Test Plan
- [x] Deploy to scratch org without namespace - all tests pass
- [x] Create package version 1.3.0 with namespace
- [x] Install in new scratch org and verify sync configuration can be saved successfully
- [x] Existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)