### PR TITLE
fix: Mark flows as templates and make invocable classes global for package visibility

### DIFF
--- a/force-app/main/default/classes/NotionSync.cls
+++ b/force-app/main/default/classes/NotionSync.cls
@@ -1,37 +1,37 @@
 /**
  * Central class containing shared data structures and types for Notion sync operations
  */
-public class NotionSync {
+global class NotionSync {
     
     /**
      * Request object for sync operations
      * Used across multiple components to pass sync request details
      */
-    public class Request {
+    global class Request {
         @InvocableVariable(
             required=true 
             label='Record ID' 
             description='ID of the record to sync'
         )
-        public String recordId;
+        global String recordId;
         
         @InvocableVariable(
             required=true 
             label='Object Type' 
             description='API name of the object (e.g., Account)'
         )
-        public String objectType;
+        global String objectType;
         
         @InvocableVariable(
             required=true 
             label='Operation Type' 
             description='CREATE, UPDATE, or DELETE'
         )
-        public String operationType;
+        global String operationType;
         
-        public Request() {}
+        global Request() {}
         
-        public Request(String recordId, String objectType, String operationType) {
+        global Request(String recordId, String objectType, String operationType) {
             this.recordId = recordId;
             this.objectType = objectType;
             this.operationType = operationType;
@@ -42,16 +42,16 @@ public class NotionSync {
      * Result object for sync operations
      * Used to return sync results
      */
-    public class Result {
+    global class Result {
         @InvocableVariable(label='Success')
-        public Boolean success;
+        global Boolean success;
         
         @InvocableVariable(label='Message')
-        public String message;
+        global String message;
         
-        public Result() {}
+        global Result() {}
         
-        public Result(Boolean success, String message) {
+        global Result(Boolean success, String message) {
             this.success = success;
             this.message = message;
         }

--- a/force-app/main/default/classes/NotionSyncInvocable.cls
+++ b/force-app/main/default/classes/NotionSyncInvocable.cls
@@ -2,7 +2,7 @@
  * Invocable class for Notion synchronization
  * Called directly from Flows to maintain user context for Named Credential access
  */
-public with sharing class NotionSyncInvocable {
+global with sharing class NotionSyncInvocable {
     
     // Test flag to disable processing during unit tests
     @TestVisible
@@ -17,7 +17,7 @@ public with sharing class NotionSyncInvocable {
         description='Synchronizes a Salesforce record to Notion database'
         category='Notion Integration'
     )
-    public static List<NotionSync.Result> syncToNotion(List<NotionSync.Request> requests) {
+    global static List<NotionSync.Result> syncToNotion(List<NotionSync.Request> requests) {
         List<NotionSync.Result> results = new List<NotionSync.Result>();
         
         // Skip processing in test context to avoid interference with unit tests

--- a/force-app/main/default/flows/NotionSync_Template_CreateUpdate.flow-meta.xml
+++ b/force-app/main/default/flows/NotionSync_Template_CreateUpdate.flow-meta.xml
@@ -73,6 +73,7 @@ Example for Account object:
         <triggerType>RecordAfterSave</triggerType>
     </start>
     <status>Draft</status>
+    <isTemplate>true</isTemplate>
     <formulas>
         <name>OperationType</name>
         <dataType>String</dataType>

--- a/force-app/main/default/flows/NotionSync_Template_Delete.flow-meta.xml
+++ b/force-app/main/default/flows/NotionSync_Template_Delete.flow-meta.xml
@@ -73,4 +73,5 @@ Example for Account object:
         <triggerType>RecordBeforeDelete</triggerType>
     </start>
     <status>Draft</status>
+    <isTemplate>true</isTemplate>
 </Flow>


### PR DESCRIPTION
## Summary
- Added `isTemplate=true` to template flows for proper package distribution
- Changed visibility of invocable classes from `public` to `global` for managed package access
- Made all necessary inner classes and members global for external visibility

## Problem
1. Template flows were not marked as templates, making them harder to discover and use in packaged environments
2. Invocable actions (NotionSyncInvocable) were not visible to users in managed package installations due to `public` visibility

## Solution
1. Added `<isTemplate>true</isTemplate>` to both template flows:
   - NotionSync_Template_CreateUpdate.flow-meta.xml
   - NotionSync_Template_Delete.flow-meta.xml

2. Updated class visibility to `global` for:
   - NotionSync class and its Request/Result inner classes
   - NotionSyncInvocable class and its syncToNotion method
   - All @InvocableVariable fields and constructors

## Test Plan
- [x] Deploy to scratch org - successful
- [x] Run all Apex tests - 100% pass rate
- [x] Flows now appear as templates in Flow Builder
- [x] Invocable actions will be accessible in managed package installations

🤖 Generated with [Claude Code](https://claude.ai/code)