### PR TITLE
feat: Add polymorphic relationship field support and improve UI layout

### DIFF
--- a/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.html
+++ b/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.html
@@ -85,7 +85,7 @@
                         <h3 class="slds-text-heading_small slds-m-bottom_small">New Relationship Mapping</h3>
                         
                         <div class="slds-grid slds-gutters slds-m-bottom_small">
-                            <div class="slds-col slds-size_1-of-3">
+                            <div class={fieldColumnClass}>
                                 <lightning-combobox
                                     name="field"
                                     label="Salesforce Relationship Field"
@@ -97,7 +97,22 @@
                                 ></lightning-combobox>
                             </div>
                             
-                            <div class="slds-col slds-size_1-of-3">
+                            <template if:true={showTargetObjectSelector}>
+                                <div class={targetObjectColumnClass}>
+                                    <lightning-combobox
+                                        name="targetObject"
+                                        label="Target Sync Object"
+                                        value={newMapping.parentObject}
+                                        placeholder="Select target object"
+                                        options={availableTargetObjects}
+                                        onchange={handleTargetObjectSelection}
+                                        required
+                                        disabled={isTargetObjectDisabled}
+                                    ></lightning-combobox>
+                                </div>
+                            </template>
+                            
+                            <div class={propertyColumnClass}>
                                 <lightning-combobox
                                     name="property"
                                     label="Notion Relation Property"
@@ -110,6 +125,14 @@
                                 ></lightning-combobox>
                             </div>
                         </div>
+
+                        <!-- Help text for polymorphic fields -->
+                        <template if:true={showTargetObjectSelector}>
+                            <div class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                                <lightning-icon icon-name="utility:info" size="x-small" class="slds-m-right_x-small"></lightning-icon>
+                                This is a polymorphic field that can reference multiple objects. Please select which sync configuration to use.
+                            </div>
+                        </template>
 
                         <div class="slds-m-top_medium">
                             <lightning-button-group>


### PR DESCRIPTION
## Summary
- Support polymorphic relationship fields (WhoId, WhatId, OwnerId) in relationship mapping UI
- Add target sync object selector when multiple objects are available
- Implement responsive column layout that adjusts based on field type

## Changes
1. **Fixed polymorphic field filtering** - The filtering logic now checks ALL objects in the `referenceTo` array instead of just the first one, allowing polymorphic fields to appear in the dropdown
2. **Added target object selector** - When a polymorphic field has multiple sync-configured target objects, users can now select which specific object to map to
3. **Dynamic layout** - The form layout now adjusts between 2 columns (for non-polymorphic fields) and 3 columns (for polymorphic fields) to avoid awkward empty spaces
4. **Help text** - Added informational text explaining polymorphic field behavior

## Test Plan
- [x] Tested in scratch org with Task object configuration
- [x] Verified WhatId field (80+ target objects) appears and allows selection
- [x] Verified WhoId field (Contact, Lead) appears and allows selection
- [x] Verified non-polymorphic fields (AccountId) use 2-column layout
- [x] Verified polymorphic fields use 3-column layout with target selector

## Screenshots
Polymorphic field with multiple target options shows target selector and uses 3-column layout.
Non-polymorphic field uses cleaner 2-column layout without empty space.

🤖 Generated with [Claude Code](https://claude.ai/code)