### PR TITLE
Fix deduplication logging status

### DIFF
--- a/force-app/main/default/classes/NotionDeduplicationQueueable.cls
+++ b/force-app/main/default/classes/NotionDeduplicationQueueable.cls
@@ -44,7 +44,8 @@ public class NotionDeduplicationQueueable implements Queueable, Database.AllowsC
                 logger.log(
                     new NotionSyncLogger.LogEntry('DEDUP_SUMMARY')
                         .withSalesforceObject(objectType)
-                        .withError('No sync configuration found for object type: ' + objectType)
+                        .withStatus('Failed')
+                        .withMessage('No sync configuration found for object type: ' + objectType)
                 );
                 return;
             }
@@ -74,7 +75,8 @@ public class NotionDeduplicationQueueable implements Queueable, Database.AllowsC
             logger.log(
                 new NotionSyncLogger.LogEntry('DEDUP_SUMMARY')
                     .withSalesforceObject(objectType)
-                    .withError('Deduplication error: ' + e.getMessage())
+                    .withStatus('Failed')
+                    .withMessage('Deduplication error: ' + e.getMessage())
             );
             
             // Re-queue if under retry limit
@@ -99,7 +101,7 @@ public class NotionDeduplicationQueueable implements Queueable, Database.AllowsC
             new NotionSyncLogger.LogEntry('DEDUP_SUMMARY')
                 .withSalesforceObject(objectType)
                 .withStatus('Deferred')
-                .withError(reason)
+                .withMessage(reason)
         );
         
         // Re-queue if not in test and under retry limit

--- a/force-app/main/default/classes/NotionNavigationController.cls
+++ b/force-app/main/default/classes/NotionNavigationController.cls
@@ -90,7 +90,8 @@ public with sharing class NotionNavigationController {
                 logger.log(
                     new NotionSyncLogger.LogEntry(operationType)
                         .withRecord(objectType, recordId)
-                        .withError('Sync failed: ' + syncEx.getMessage())
+                        .withStatus('Failed')
+                        .withMessage('Sync failed: ' + syncEx.getMessage())
                 );
                 
                 // Now we can flush the logs (DML after callout is complete)

--- a/force-app/main/default/classes/NotionSyncBatchQueueable.cls
+++ b/force-app/main/default/classes/NotionSyncBatchQueueable.cls
@@ -182,20 +182,20 @@ public class NotionSyncBatchQueueable implements Queueable, Database.AllowsCallo
             if (result.status == 'Success') {
                 batchLog.withStatus('Success');
                 // Add batch details to error message field for successful batches
-                batchLog.errorMessage = batchDetails;
+                batchLog.message = batchDetails;
             } else if (result.status == 'Rate Limited') {
                 batchLog.withRateLimit(result.retryAfterSeconds != null ? result.retryAfterSeconds : 1);
                 String errorMsg = batchDetails;
                 if (result.errorMessage != null) {
                     errorMsg += ' | Error: ' + result.errorMessage;
                 }
-                batchLog.withError(errorMsg);
+                batchLog.withStatus('Failed').withMessage(errorMsg);
             } else if (result.status == 'Error' || result.errorMessage != null) {
                 String errorMsg = batchDetails;
                 if (result.errorMessage != null) {
                     errorMsg += ' | Error: ' + result.errorMessage;
                 }
-                batchLog.withError(errorMsg);
+                batchLog.withStatus('Failed').withMessage(errorMsg);
             }
             
             // Log the batch result
@@ -256,10 +256,10 @@ public class NotionSyncBatchQueueable implements Queueable, Database.AllowsCallo
         
         // Set status based on overall results
         if (totalFailed > 0 || totalDeferred > 0) {
-            summaryLog.withError(summaryMessage);
+            summaryLog.withStatus('Failed').withMessage(summaryMessage);
         } else {
             summaryLog.withStatus('Success');
-            summaryLog.errorMessage = summaryMessage;
+            summaryLog.message = summaryMessage;
         }
         
         logger.log(summaryLog);
@@ -275,7 +275,8 @@ public class NotionSyncBatchQueueable implements Queueable, Database.AllowsCallo
         // Log error using instance logger - use CREATE as operation type
         logger.log(
             new NotionSyncLogger.LogEntry('BATCH')
-                .withError('Batch processing error: ' + e.getMessage())
+                .withStatus('Failed')
+                .withMessage('Batch processing error: ' + e.getMessage())
         );
         
         // Don't rethrow - let the job complete
@@ -355,7 +356,8 @@ public class NotionSyncBatchQueueable implements Queueable, Database.AllowsCallo
                 System.debug('Deduplication error: ' + e.getMessage());
                 logger.log(
                     new NotionSyncLogger.LogEntry('DEDUP_SUMMARY')
-                        .withError('Deduplication error: ' + e.getMessage())
+                        .withStatus('Failed')
+                        .withMessage('Deduplication error: ' + e.getMessage())
                 );
             }
         } else {

--- a/force-app/main/default/classes/NotionSyncLogger.cls
+++ b/force-app/main/default/classes/NotionSyncLogger.cls
@@ -39,7 +39,7 @@ public with sharing class NotionSyncLogger {
                 Object_Type__c = entry.objectType,
                 Operation_Type__c = entry.operationType,
                 Status__c = entry.status,
-                Error_Message__c = entry.errorMessage,
+                Error_Message__c = entry.message,
                 Retry_Count__c = entry.retryCount,
                 Notion_Page_Id__c = entry.notionPageId,
                 Rate_Limited__c = entry.rateLimited,
@@ -87,7 +87,7 @@ public with sharing class NotionSyncLogger {
         public String objectType;
         public String operationType;
         public String status;
-        public String errorMessage;
+        public String message;
         public Integer retryCount;
         public String notionPageId;
         public Boolean rateLimited;
@@ -104,7 +104,7 @@ public with sharing class NotionSyncLogger {
         public LogEntry(String operationType) {
             this.operationType = operationType;
             this.status = 'Success';
-            this.errorMessage = null;
+            this.message = null;
             this.retryCount = 0;
             this.notionPageId = null;
             this.rateLimited = false;
@@ -137,9 +137,9 @@ public with sharing class NotionSyncLogger {
             return this;
         }
         
-        public LogEntry withError(String errorMessage) {
-            this.errorMessage = errorMessage;
-            this.status = 'Failed';
+        public LogEntry withMessage(String message) {
+            this.message = message;
+            // Does NOT change status - leaves it as is
             return this;
         }
         

--- a/force-app/main/default/classes/NotionSyncLoggerTest.cls
+++ b/force-app/main/default/classes/NotionSyncLoggerTest.cls
@@ -114,7 +114,8 @@ private class NotionSyncLoggerTest {
         logger.log(
             new NotionSyncLogger.LogEntry('DELETE')
                 .withRecord('Opportunity', '001000000000003')
-                .withError('Record not found in Notion')
+                .withStatus('Failed')
+                .withMessage('Record not found in Notion')
                 .withRetryCount(2)
         );
         
@@ -147,7 +148,8 @@ private class NotionSyncLoggerTest {
         logger.log(
             new NotionSyncLogger.LogEntry('UPDATE')
                 .withRecord('Lead', '001000000000005')
-                .withError('Error')
+                .withStatus('Failed')
+                .withMessage('Error')
         );
         
         // Clear logs without saving

--- a/force-app/main/default/classes/NotionSyncProcessor.cls
+++ b/force-app/main/default/classes/NotionSyncProcessor.cls
@@ -66,7 +66,8 @@ public class NotionSyncProcessor {
             logger.log(
                 new NotionSyncLogger.LogEntry(request.operationType)
                     .withRecord(request.objectType, request.recordId)
-                    .withError(errorMessage)
+                    .withStatus('Failed')
+                    .withMessage(errorMessage)
             );
         }
     }
@@ -176,7 +177,8 @@ public class NotionSyncProcessor {
             logger.log(
                 new NotionSyncLogger.LogEntry(request.operationType)
                     .withRecord(request.objectType, request.recordId)
-                    .withError(e.getMessage())
+                    .withStatus('Failed')
+                    .withMessage(e.getMessage())
                     .withRateLimit(1)  // Default to 1 second retry
             );
         } catch (Exception e) {
@@ -184,7 +186,8 @@ public class NotionSyncProcessor {
             logger.log(
                 new NotionSyncLogger.LogEntry(request.operationType)
                     .withRecord(request.objectType, request.recordId)
-                    .withError(e.getMessage())
+                    .withStatus('Failed')
+                    .withMessage(e.getMessage())
             );
         }
     }
@@ -605,13 +608,13 @@ public class NotionSyncProcessor {
                             result.duplicatesDeleted++;
                             deletionCount++;
                             
-                            // Log individual deletion
+                            // Log individual deletion as success
                             logger.log(
                                 new NotionSyncLogger.LogEntry('DEDUP')
                                     .withRecord(syncConfig.ObjectApiName__c, salesforceId)
                                     .withNotionPageId(pageId)
                                     .withStatus('Success')
-                                    .withError('Duplicate Notion page deleted')
+                                    .withMessage('Duplicate Notion page deleted')
                             );
                             
                         } catch (NotionRateLimiter.RateLimitException e) {
@@ -621,7 +624,8 @@ public class NotionSyncProcessor {
                                 new NotionSyncLogger.LogEntry('DEDUP')
                                     .withRecord(syncConfig.ObjectApiName__c, salesforceId)
                                     .withNotionPageId(pageId)
-                                    .withError('Rate limit during deduplication: ' + e.getMessage())
+                                    .withStatus('Failed')
+                                    .withMessage('Rate limit during deduplication: ' + e.getMessage())
                                     .withRateLimit(1)
                             );
                             return result;
@@ -632,7 +636,8 @@ public class NotionSyncProcessor {
                                 new NotionSyncLogger.LogEntry('DEDUP')
                                     .withRecord(syncConfig.ObjectApiName__c, salesforceId)
                                     .withNotionPageId(pageId)
-                                    .withError('Failed to delete duplicate: ' + e.getMessage())
+                                    .withStatus('Failed')
+                                    .withMessage('Failed to delete duplicate: ' + e.getMessage())
                             );
                         }
                     }
@@ -643,7 +648,8 @@ public class NotionSyncProcessor {
             logger.log(
                 new NotionSyncLogger.LogEntry('DEDUP_SUMMARY')
                     .withSalesforceObject(syncConfig.ObjectApiName__c)
-                    .withError('Deduplication error: ' + e.getMessage())
+                    .withStatus('Failed')
+                    .withMessage('Deduplication error: ' + e.getMessage())
             );
         }
         

--- a/force-app/main/default/objects/Notion_Sync_Log__c/fields/Error_Message__c.field-meta.xml
+++ b/force-app/main/default/objects/Notion_Sync_Log__c/fields/Error_Message__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Error_Message__c</fullName>
-    <description>Error details if the sync failed</description>
+    <description>Message details about the sync operation</description>
     <externalId>false</externalId>
-    <label>Error Message</label>
+    <label>Message</label>
     <length>32768</length>
     <trackTrending>false</trackTrending>
     <type>LongTextArea</type>


### PR DESCRIPTION
## Summary
- Fix issue where successfully deleted duplicate Notion pages were being logged as "Failed" in sync logs
- Refactor NotionSyncLogger API for clarity by replacing `withError()` with `withMessage()`
- Separate status setting from message setting to avoid confusion

## Changes
1. **NotionSyncLogger.cls**
   - Removed `withError()` method that automatically set status to 'Failed'
   - Added `withMessage()` method that sets message without changing status
   - Changed internal property from `errorMessage` to `message`

2. **Field Metadata**
   - Changed `Error_Message__c` field label from "Error Message" to "Message"
   - Updated field description to reflect it's for any sync operation message

3. **Updated Classes**
   - NotionSyncProcessor.cls: Fixed duplicate deletion logging to use `withStatus('Success').withMessage()`
   - NotionDeduplicationQueueable.cls: Updated to use new API
   - NotionNavigationController.cls: Updated to use new API
   - NotionSyncBatchQueueable.cls: Updated to use new API
   - NotionSyncLoggerTest.cls: Updated tests for new API

## Test Results
- All unit tests pass
- Verified deduplication now correctly logs deletions as "Success"
- Tested that other sync operations still log correctly

## Breaking Changes
None - the field API name remains `Error_Message__c` for backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)