### PR TITLE
Fix deduplication comparator stability and add event timestamp logging

### DIFF
--- a/force-app/integration/default/classes/NotionIntegrationTestExecutor.cls
+++ b/force-app/integration/default/classes/NotionIntegrationTestExecutor.cls
@@ -1561,12 +1561,12 @@ public class NotionIntegrationTestExecutor {
         List<Notion_Sync_Log__c> dedupLogs = [
             SELECT Id, Record_Id__c, Object_Type__c, Operation_Type__c, 
                    Status__c, Error_Message__c, Duplicates_Found__c, 
-                   Duplicates_Deleted__c, Deduplication_Deferred__c
+                   Duplicates_Deleted__c, Deduplication_Deferred__c, Event_Timestamp__c
             FROM Notion_Sync_Log__c
             WHERE (Record_Id__c IN (:dedupAccount.Id, :dedupParent.Id) OR Operation_Type__c = 'DEDUP_SUMMARY')
             AND Operation_Type__c IN ('DEDUP', 'DEDUP_SUMMARY', 'UPDATE')
             AND CreatedDate = TODAY
-            ORDER BY CreatedDate DESC
+            ORDER BY Event_Timestamp__c DESC
         ];
         
         System.debug('Found ' + dedupLogs.size() + ' deduplication logs');

--- a/force-app/main/default/classes/NotionSyncLogger.cls
+++ b/force-app/main/default/classes/NotionSyncLogger.cls
@@ -21,6 +21,9 @@ public with sharing class NotionSyncLogger {
         // Set callouts used at the time of logging
         entry.calloutsUsed = Limits.getCallouts();
         
+        // Capture the actual event timestamp
+        entry.eventTimestamp = DateTime.now();
+        
         logs.add(entry);
     }
     
@@ -49,7 +52,8 @@ public with sharing class NotionSyncLogger {
                 Callouts_Used__c = entry.calloutsUsed,
                 Duplicates_Found__c = entry.duplicatesFound,
                 Duplicates_Deleted__c = entry.duplicatesDeleted,
-                Deduplication_Deferred__c = entry.deduplicationDeferred
+                Deduplication_Deferred__c = entry.deduplicationDeferred,
+                Event_Timestamp__c = entry.eventTimestamp
             );
             
             logRecords.add(logRecord);
@@ -99,6 +103,7 @@ public with sharing class NotionSyncLogger {
         public Integer duplicatesFound;
         public Integer duplicatesDeleted;
         public Boolean deduplicationDeferred;
+        public DateTime eventTimestamp;
         
         // Constructor with only operationType - all other fields are optional
         public LogEntry(String operationType) {

--- a/force-app/main/default/classes/NotionSyncProcessor.cls
+++ b/force-app/main/default/classes/NotionSyncProcessor.cls
@@ -783,11 +783,33 @@ public class NotionSyncProcessor {
             String time1 = (String) page1.get('created_time');
             String time2 = (String) page2.get('created_time');
             
-            if (time1 == null && time2 == null) return 0;
+            if (time1 == null && time2 == null) {
+                // If both times are null, use ID as secondary sort
+                return compareByPageId(page1, page2);
+            }
             if (time1 == null) return 1;
             if (time2 == null) return -1;
             
-            return time1.compareTo(time2);
+            // Compare times
+            Integer timeComparison = time1.compareTo(time2);
+            
+            // If times are equal, use page ID as secondary sort for stable ordering
+            if (timeComparison == 0) {
+                return compareByPageId(page1, page2);
+            }
+            
+            return timeComparison;
+        }
+        
+        private Integer compareByPageId(Map<String, Object> page1, Map<String, Object> page2) {
+            String id1 = (String) page1.get('id');
+            String id2 = (String) page2.get('id');
+            
+            if (id1 == null && id2 == null) return 0;
+            if (id1 == null) return 1;
+            if (id2 == null) return -1;
+            
+            return id1.compareTo(id2);
         }
     }
 }

--- a/force-app/main/default/objects/Notion_Sync_Log__c/fields/Event_Timestamp__c.field-meta.xml
+++ b/force-app/main/default/objects/Notion_Sync_Log__c/fields/Event_Timestamp__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Timestamp__c</fullName>
+    <description>The actual timestamp when the sync event occurred, used for accurate deduplication</description>
+    <externalId>false</externalId>
+    <label>Event Timestamp</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/Notion_Integration_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Notion_Integration_User.permissionset-meta.xml
@@ -61,6 +61,11 @@
         <field>Notion_Sync_Log__c.Rate_Limit_Retry_After__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Notion_Sync_Log__c.Event_Timestamp__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Notion Integration User</label>
     <objectPermissions>

--- a/force-app/main/default/permissionsets/Notion_Sync_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Notion_Sync_Admin.permissionset-meta.xml
@@ -96,4 +96,9 @@
         <field>Notion_Sync_Log__c.Retry_Count__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Notion_Sync_Log__c.Event_Timestamp__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
 </PermissionSet>


### PR DESCRIPTION
## Summary
- Fixed non-deterministic behavior in NotionPageCreatedTimeComparator when timestamps are identical
- Added Event_Timestamp__c field to capture accurate sync event timing

## Changes

### 1. Stable Secondary Sort for Deduplication
When multiple Notion pages have identical `created_time` timestamps, the comparator now uses page ID as a secondary sort key. This ensures deterministic ordering during deduplication, preventing unpredictable behavior when timestamps are equal.

### 2. Event Timestamp Field
Added `Event_Timestamp__c` field to `Notion_Sync_Log__c` to capture the actual time when sync events occur, separate from the `CreatedDate` which is set when logs are flushed. This provides more accurate timestamps for sync event ordering.

**Components updated:**
- Added `Event_Timestamp__c` DateTime field to `Notion_Sync_Log__c`
- Updated `NotionSyncLogger` to capture event timestamp on `log()`
- Added field permissions to `Notion_Integration_User` and `Notion_Sync_Admin`
- Updated integration test to order by `Event_Timestamp__c`

## Test plan
- [x] Unit tests pass
- [x] Integration tests updated to use Event_Timestamp__c for ordering
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)