### PR TITLE
fix: Add stub classes for deprecated batch processing

### DIFF
--- a/force-app/main/default/classes/NotionSyncBatchProcessor.cls
+++ b/force-app/main/default/classes/NotionSyncBatchProcessor.cls
@@ -1,8 +1,9 @@
 /**
  * @deprecated This class is deprecated as of version 1.13.0
  * Use NotionSyncQueueable with runtime limit checking instead.
+ * 
+ * This is a stub class maintained for managed package compatibility only.
  */
-@deprecated
 public class NotionSyncBatchProcessor {
     // This class is deprecated and no longer used
 }

--- a/force-app/main/default/classes/NotionSyncBatchProcessor.cls
+++ b/force-app/main/default/classes/NotionSyncBatchProcessor.cls
@@ -1,0 +1,8 @@
+/**
+ * @deprecated This class is deprecated as of version 1.13.0
+ * Use NotionSyncQueueable with runtime limit checking instead.
+ */
+@deprecated
+public class NotionSyncBatchProcessor {
+    // This class is deprecated and no longer used
+}

--- a/force-app/main/default/classes/NotionSyncBatchProcessor.cls-meta.xml
+++ b/force-app/main/default/classes/NotionSyncBatchProcessor.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NotionSyncBatchProcessorTest.cls
+++ b/force-app/main/default/classes/NotionSyncBatchProcessorTest.cls
@@ -1,0 +1,11 @@
+/**
+ * @deprecated This test class is deprecated as of version 1.13.0
+ */
+@isTest
+private class NotionSyncBatchProcessorTest {
+    @isTest
+    static void testDeprecated() {
+        // This test class is deprecated and no longer used
+        System.assert(true, 'Deprecated test placeholder');
+    }
+}

--- a/force-app/main/default/classes/NotionSyncBatchProcessorTest.cls-meta.xml
+++ b/force-app/main/default/classes/NotionSyncBatchProcessorTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NotionSyncBatchQueueable.cls
+++ b/force-app/main/default/classes/NotionSyncBatchQueueable.cls
@@ -1,8 +1,9 @@
 /**
  * @deprecated This class is deprecated as of version 1.13.0
  * Use NotionSyncQueueable with runtime limit checking instead.
+ * 
+ * This is a stub class maintained for managed package compatibility only.
  */
-@deprecated
 public class NotionSyncBatchQueueable implements Queueable {
     // This class is deprecated and no longer used
     public void execute(QueueableContext context) {

--- a/force-app/main/default/classes/NotionSyncBatchQueueable.cls
+++ b/force-app/main/default/classes/NotionSyncBatchQueueable.cls
@@ -1,0 +1,11 @@
+/**
+ * @deprecated This class is deprecated as of version 1.13.0
+ * Use NotionSyncQueueable with runtime limit checking instead.
+ */
+@deprecated
+public class NotionSyncBatchQueueable implements Queueable {
+    // This class is deprecated and no longer used
+    public void execute(QueueableContext context) {
+        // No-op - deprecated
+    }
+}

--- a/force-app/main/default/classes/NotionSyncBatchQueueable.cls-meta.xml
+++ b/force-app/main/default/classes/NotionSyncBatchQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary

This PR adds minimal stub classes for the deprecated batch processing components to satisfy Salesforce managed package requirements.

## Context

When attempting to create a new package version, we encountered an error:
> Can't create package version. Before you can remove metadata components from a second-generation managed package, you must first request access to this feature by logging a case in the Salesforce Partner Community.

Salesforce doesn't allow removing classes from managed packages without special permission. Instead, we need to keep the classes but mark them as deprecated.

## Changes

Added minimal stub implementations for:
-  - Empty class marked as @deprecated
-  - Minimal Queueable implementation marked as @deprecated  
-  - Single placeholder test marked as @deprecated

All classes include deprecation notices pointing to the new  with runtime limit checking.

## Testing

These are empty stub classes that don't affect functionality. The real implementation is in .

🤖 Generated with Claude Code