### PR TITLE
fix: Persist widget column reorder + add --bump flag to build-package.sh

### DIFF
--- a/force-app/main/default/lwc/notionWidgetColumnConfigurator/notionWidgetColumnConfigurator.js
+++ b/force-app/main/default/lwc/notionWidgetColumnConfigurator/notionWidgetColumnConfigurator.js
@@ -236,8 +236,12 @@ export default class NotionWidgetColumnConfigurator extends LightningElement {
     }
 
     notifyChange() {
+        // swapColumns mutates displayOrder values without reordering the internal
+        // array, so emit a copy sorted by displayOrder. Otherwise the consumer would
+        // persist the columns in their original creation order and the user's
+        // reorder would be silently lost on save.
         this.dispatchEvent(new CustomEvent('columnchange', {
-            detail: { columns: this.columns }
+            detail: { columns: this.sortedColumns }
         }));
     }
 

--- a/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.js
+++ b/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.js
@@ -475,13 +475,17 @@ export default class NotionWidgetDesigner extends LightningElement {
         this.isLoading = true;
         try {
             const widgetDev = this.editingWidget.developerName;
-            // Transform columns to match expected format
-            const columnsToSave = (this.editingWidget.columns || []).map((col, index) => ({
+            // Transform columns to match expected format.
+            // Defensive sort by displayOrder: Apex persists DisplayOrder__c from the
+            // array index, so the array order is what actually defines the saved order.
+            const orderedColumns = [...(this.editingWidget.columns || [])]
+                .sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0));
+            const columnsToSave = orderedColumns.map((col, index) => ({
                 developerName: buildChildDevName(widgetDev, col.developerName, col.propertyName, index, 'col'),
                 label: col.label || col.propertyName,
                 notionPropertyName: col.propertyName,
                 notionPropertyType: col.propertyType,
-                displayOrder: col.displayOrder,
+                displayOrder: index + 1,
                 columnWidth: col.columnWidth,
                 isVisible: col.isVisible !== false,
                 isSortable: col.isSortable !== false

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -14,6 +14,7 @@ CODE_COVERAGE=true
 PACKAGE_ID=""
 PACKAGE_NAME="Notion Salesforce Sync"
 VERSION_DESCRIPTION=""
+BUMP="minor"
 
 # Load environment variables if .env file exists
 if [ -f .env ]; then
@@ -44,6 +45,10 @@ while [[ $# -gt 0 ]]; do
             VERSION_DESCRIPTION="$2"
             shift 2
             ;;
+        --bump)
+            BUMP="$2"
+            shift 2
+            ;;
         --skip-validation)
             SKIP_VALIDATION=true
             shift
@@ -61,6 +66,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --package-id <id>            The package ID (defaults to NOTION_SYNC_PACKAGE_ID from .env)"
             echo "  --wait <minutes>             Wait time for package creation (default: 20)"
             echo "  --version-description <desc> Version description for the package"
+            echo "  --bump <minor|major>         Bump the major or minor version (default: minor)"
             echo "  --skip-validation            Skip validation during package creation"
             echo "  --no-code-coverage           Skip code coverage calculation"
             echo "  --help                       Show this help message"
@@ -170,10 +176,15 @@ if command -v jq &> /dev/null; then
         # Extract major and minor versions
         MAJOR=$(echo "$LATEST_VERSION" | cut -d. -f1)
         MINOR=$(echo "$LATEST_VERSION" | cut -d. -f2)
-        # Increment minor version
-        NEXT_MINOR=$((MINOR + 1))
-        VERSION_NUMBER="${MAJOR}.${NEXT_MINOR}.0.NEXT"
-        VERSION_NAME="Version ${MAJOR}.${NEXT_MINOR}"
+        if [ "$BUMP" = "major" ]; then
+            NEXT_MAJOR=$((MAJOR + 1))
+            VERSION_NUMBER="${NEXT_MAJOR}.0.0.NEXT"
+            VERSION_NAME="Version ${NEXT_MAJOR}.0"
+        else
+            NEXT_MINOR=$((MINOR + 1))
+            VERSION_NUMBER="${MAJOR}.${NEXT_MINOR}.0.NEXT"
+            VERSION_NAME="Version ${MAJOR}.${NEXT_MINOR}"
+        fi
     else
         # Default to 1.0 if no versions exist
         VERSION_NUMBER="1.0.0.NEXT"


### PR DESCRIPTION
## Summary

Follow-up fixes after merging the Notion Widget feature (PR #97 / v2.0.0.1).

### `fix`: Widget column reorder was silently reverted on save

In the column configurator, the move-up / move-down arrows call
`swapColumns`, which only swapped the `displayOrder` field on the two
affected rows. The internal `this.columns` array was left in its
original (creation) order, and `notifyChange()` then emitted that
array. The Apex save path persists `DisplayOrder__c` from the array
index (`i + 1`), so the user's reorder never made it to metadata — the
widget would render in the original order on the next load.

Two fixes:
- `notionWidgetColumnConfigurator.notifyChange()` now emits `this.sortedColumns` (sorted by `displayOrder`) so consumers see the row order the user actually arranged.
- `notionWidgetDesigner.handleSaveWidget()` re-sorts by `displayOrder` and renumbers `1..N` defensively, so the persisted order is consistent even if a future caller sends columns out of order.

Verified in the scratch org: reordering columns in the designer and saving now persists the correct `DisplayOrder__c` values; reopening the widget shows columns in the new order; the runtime widget on the record page also renders in the new order.

### `chore`: `--bump major|minor` flag on `build-package.sh`

Previously the script always incremented the minor version, so cutting a major release required hand-editing `sfdx-project.json` or the script. Added a `--bump` flag (default: `minor`) so the script can be invoked as `./scripts/build-package.sh --bump major` to roll the major version (used to cut v2.0.0.1).

## Test plan

- [ ] CI: deploy to scratch org + full Apex test suite passes
- [x] Manual: reorder Test_Child_Records widget columns in the designer; SOQL confirms `DisplayOrder__c` reflects the new order; reload of the designer + runtime page shows the persisted order
- [x] `./scripts/build-package.sh --bump major` produces a `${MAJOR+1}.0.0.NEXT` version (used to build the v2.0.0.1 managed package)