### PR TITLE
feat: Add widget config dropdown in Lightning App Builder

### DIFF
--- a/force-app/main/default/classes/NotionWidgetPicklist.cls
+++ b/force-app/main/default/classes/NotionWidgetPicklist.cls
@@ -1,0 +1,28 @@
+/**
+ * Lightning App Builder dynamic pick list for selecting a registered
+ * NotionWidget__mdt configuration. Surfaces a dropdown of widget developer
+ * names on the Notion Widget component's property panel so admins no longer
+ * have to type the developer name by hand.
+ */
+global class NotionWidgetPicklist extends VisualEditor.DynamicPickList {
+
+    global override VisualEditor.DataRow getDefaultValue() {
+        return null;
+    }
+
+    global override VisualEditor.DynamicPickListRows getValues() {
+        VisualEditor.DynamicPickListRows rows = new VisualEditor.DynamicPickListRows();
+        for (NotionWidget__mdt widget : [
+            SELECT DeveloperName, MasterLabel, IsActive__c
+            FROM NotionWidget__mdt
+            ORDER BY MasterLabel ASC
+        ]) {
+            String label = widget.MasterLabel + ' (' + widget.DeveloperName + ')';
+            if (widget.IsActive__c == false) {
+                label += ' [Inactive]';
+            }
+            rows.addRow(new VisualEditor.DataRow(label, widget.DeveloperName));
+        }
+        return rows;
+    }
+}

--- a/force-app/main/default/classes/NotionWidgetPicklist.cls-meta.xml
+++ b/force-app/main/default/classes/NotionWidgetPicklist.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NotionWidgetPicklistTest.cls
+++ b/force-app/main/default/classes/NotionWidgetPicklistTest.cls
@@ -1,0 +1,23 @@
+@IsTest
+private class NotionWidgetPicklistTest {
+
+    @IsTest
+    static void testGetValuesReturnsRows() {
+        Test.startTest();
+        NotionWidgetPicklist picklist = new NotionWidgetPicklist();
+        VisualEditor.DynamicPickListRows rows = picklist.getValues();
+        Test.stopTest();
+
+        System.assertNotEquals(null, rows, 'Picklist should return a non-null rows container');
+    }
+
+    @IsTest
+    static void testGetDefaultValueIsNull() {
+        Test.startTest();
+        NotionWidgetPicklist picklist = new NotionWidgetPicklist();
+        VisualEditor.DataRow defaultValue = picklist.getDefaultValue();
+        Test.stopTest();
+
+        System.assertEquals(null, defaultValue, 'Default value should be null so the admin makes an explicit choice');
+    }
+}

--- a/force-app/main/default/classes/NotionWidgetPicklistTest.cls-meta.xml
+++ b/force-app/main/default/classes/NotionWidgetPicklistTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/notionWidget/notionWidget.js-meta.xml
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.js-meta.xml
@@ -12,7 +12,8 @@
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage,lightning__AppPage,lightning__HomePage">
             <property name="widgetDeveloperName" type="String" label="Widget Configuration"
-                      description="The Developer Name of the NotionWidget custom metadata configuration" required="true"/>
+                      description="The Developer Name of the NotionWidget custom metadata configuration"
+                      datasource="apex://NotionWidgetPicklist" required="true"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
## Summary
- Adds a `VisualEditor.DynamicPickList` Apex class (`NotionWidgetPicklist`) that powers the Notion Widget's `widgetDeveloperName` property in the Lightning App Builder property panel.
- The property now renders as a dropdown of registered `NotionWidget__mdt` entries (formatted as `Label (DeveloperName)`, with `[Inactive]` suffix when `IsActive__c == false`) instead of a free-text input where the admin had to type the developer name by hand.
- Wired up via `datasource="apex://NotionWidgetPicklist"` on the LWC's `.js-meta.xml`.

## Test plan
- [x] Apex tests (`NotionWidgetPicklistTest`) pass.
- [x] Manually verified in the scratch org: opened the Test Parent Object Record Page in App Builder, clicked the Notion Widget, confirmed the Widget Configuration field renders as a typeahead dropdown listing all 4 registered widgets with the current selection checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)