### PR TITLE
fix: Clip widget table cells so content stays inside column bounds

### DIFF
--- a/force-app/main/default/lwc/notionWidget/notionWidget.css
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.css
@@ -16,6 +16,28 @@
     margin-left: 0;
 }
 
+/* slds-table_fixed-layout sets table-layout: fixed but does not clip cell
+   content. Without overflow:hidden the title link and badge spans escape
+   the cell box and visually overlap adjacent columns. */
+.notion-widget-table-wrapper td {
+    overflow: hidden;
+    vertical-align: top;
+}
+
+/* Title link and the direct text spans (text / number / date) need
+   inline-block + ellipsis to actually truncate inside a fixed-layout cell;
+   plain text inheriting nowrap from slds-truncate alone is not enough
+   because the anchor itself has no width constraint. */
+.notion-widget-table-wrapper td > a,
+.notion-widget-table-wrapper td > span {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
 .slds-alert_error {
     background-color: #c23934;
     color: white;


### PR DESCRIPTION
## Summary
- `slds-table_fixed-layout` sets `table-layout: fixed` but does not apply `overflow: hidden` to `td` elements, so a long title link or single-badge span would visually overlap the next column.
- Adds `overflow: hidden` + `vertical-align: top` to `td`, and forces direct `> a` / `> span` children to `inline-block` with `max-width: 100%` + `text-overflow: ellipsis` so they truncate inside the cell.

## Test plan
- [x] Manually verified in the scratch org: the Test Child Records widget on a Test Parent record page now shows "Integration Test Child 17..." / "Integration Test Parent 177..." truncated cleanly inside their columns instead of bleeding into adjacent columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)