### PR TITLE
feat: Polish widget runtime to match native related list UX

### DIFF
--- a/force-app/main/default/lwc/notionWidget/notionWidget.css
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.css
@@ -3,40 +3,22 @@
 }
 
 .notion-widget-table-wrapper {
+    /* Per CSS spec, setting overflow-x to a non-visible value promotes
+       overflow-y from `visible` to `auto`, which gave us a stray vertical
+       scrollbar even when all rows fit. Explicitly setting overflow-y to
+       hidden keeps the horizontal scrollbar (when the table is wider than
+       the card) without ever spawning a vertical scrollbar — the card
+       grows to fit the rows and the page handles vertical scroll. */
     overflow-x: auto;
-}
-
-.notion-widget-table-wrapper table th .slds-th__action {
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
+    overflow-y: hidden;
 }
 
 .notion-widget-table-wrapper td a + a {
     margin-left: 0;
 }
 
-/* slds-table_fixed-layout sets table-layout: fixed but does not clip cell
-   content. Without overflow:hidden the title link and badge spans escape
-   the cell box and visually overlap adjacent columns. */
-.notion-widget-table-wrapper td {
-    overflow: hidden;
-    vertical-align: top;
-}
-
-/* Title link and the direct text spans (text / number / date) need
-   inline-block + ellipsis to actually truncate inside a fixed-layout cell;
-   plain text inheriting nowrap from slds-truncate alone is not enough
-   because the anchor itself has no width constraint. */
-.notion-widget-table-wrapper td > a,
-.notion-widget-table-wrapper td > span {
-    display: inline-block;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    vertical-align: middle;
-}
+/* SLDS data table pattern handles td truncation natively via
+   <div class="slds-truncate" title="..."> inside each <td role="gridcell">. */
 
 .slds-alert_error {
     background-color: #c23934;
@@ -51,4 +33,31 @@
 .notion-widget-untitled {
     font-style: italic;
     color: #706e6b;
+}
+
+/* Column resize uses SLDS's standard pattern (slds-table_resizable-cols on
+   the table + .slds-resizable / .slds-resizable__handle / .slds-resizable__divider
+   inside each sortable th). SLDS sets up all positioning, padding, hover
+   states, and divider visuals; we only need to wire mousedown on the handle
+   to drive width state. No CSS overrides necessary here. */
+
+/* Wrapper made relative so the refresh-overlay spinner can sit on top of
+   the existing table during sort / refresh without removing the data. */
+.notion-widget-table-wrapper-relative {
+    position: relative;
+}
+
+.notion-widget-loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.55);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 2rem;
+    z-index: 2;
+    pointer-events: none;
 }

--- a/force-app/main/default/lwc/notionWidget/notionWidget.html
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.html
@@ -1,26 +1,26 @@
 <template>
     <lightning-card title={widgetTitle} icon-name="custom:custom63">
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center">
-            <template if:true={showNewButton}>
-                <lightning-button
-                    label="New"
-                    icon-name="utility:add"
-                    variant="brand"
-                    onclick={handleCreate}
-                    disabled={createDisabled}
-                    class="slds-m-right_x-small">
-                </lightning-button>
-            </template>
             <lightning-button-icon
                 icon-name="utility:refresh"
                 alternative-text="Refresh"
                 title="Refresh"
+                variant="border-filled"
                 onclick={handleRefresh}
-                disabled={isLoading}>
+                disabled={isLoading}
+                class="slds-m-right_x-small">
             </lightning-button-icon>
+            <template if:true={showNewButton}>
+                <lightning-button
+                    label="New"
+                    variant="neutral"
+                    onclick={handleCreate}
+                    disabled={createDisabled}>
+                </lightning-button>
+            </template>
         </div>
 
-        <template if:true={isLoading}>
+        <template if:true={showInitialSpinner}>
             <div class="slds-is-relative slds-p-around_large">
                 <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
             </div>
@@ -35,26 +35,41 @@
             </div>
         </template>
 
-        <template if:false={isLoading}>
-            <template if:false={hasError}>
-                <template if:true={hasData}>
-                    <div class="notion-widget-table-wrapper">
-                        <table class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_fixed-layout">
+        <template if:false={hasError}>
+            <template if:true={hasData}>
+                <div class="notion-widget-table-wrapper notion-widget-table-wrapper-relative">
+                    <template if:true={showRefreshOverlay}>
+                        <div class="notion-widget-loading-overlay">
+                            <lightning-spinner alternative-text="Refreshing" size="small"></lightning-spinner>
+                        </div>
+                    </template>
+                    <table class="slds-table slds-table_bordered slds-table_fixed-layout slds-table_resizable-cols" role="grid">
                             <thead>
                                 <tr class="slds-line-height_reset">
                                     <template for:each={headerColumns} for:item="col">
-                                        <th key={col.key} scope="col" style={col.width}>
+                                        <th key={col.key} scope="col" style={col.width} class={col.thClass} aria-label={col.label} aria-sort={col.ariaSort}>
                                             <template if:true={col.isSortable}>
-                                                <a class="slds-th__action slds-text-link_reset" data-property={col.propertyName} onclick={handleSortClick}>
-                                                    <span class="slds-truncate">{col.label}</span>
-                                                    <template if:true={col.hasSortIcon}>
-                                                        <lightning-icon icon-name={col.sortIcon} size="xx-small" class="slds-m-left_xx-small"></lightning-icon>
-                                                    </template>
+                                                <a class="slds-th__action slds-text-link_reset" href="javascript:void(0);" role="button" tabindex="0" data-property={col.propertyName} onclick={handleSortClick}>
+                                                    <span class="slds-assistive-text">Sort by: </span>
+                                                    <div class="slds-grid slds-grid_vertical-align-center slds-has-flexi-truncate">
+                                                        <span class="slds-truncate" title={col.label}>{col.label}</span>
+                                                        <lightning-icon icon-name={col.sortIcon} size="xx-small" class="slds-m-left_xx-small slds-is-sortable__icon"></lightning-icon>
+                                                    </div>
                                                 </a>
                                             </template>
                                             <template if:false={col.isSortable}>
-                                                <div class="slds-truncate" title={col.label}>{col.label}</div>
+                                                <div class="slds-th__action">
+                                                    <div class="slds-grid slds-grid_vertical-align-center slds-has-flexi-truncate">
+                                                        <span class="slds-truncate" title={col.label}>{col.label}</span>
+                                                    </div>
+                                                </div>
                                             </template>
+                                            <div class="slds-resizable">
+                                                <input type="range" class="slds-resizable__input slds-assistive-text" aria-label={col.label} max="1000" min="20" tabindex="-1">
+                                                <span class="slds-resizable__handle" data-property={col.propertyName} onmousedown={handleResizeStart}>
+                                                    <span class="slds-resizable__divider"></span>
+                                                </span>
+                                            </div>
                                         </th>
                                     </template>
                                 </tr>
@@ -63,86 +78,80 @@
                                 <template for:each={rows} for:item="row">
                                     <tr key={row.id} class="slds-hint-parent">
                                         <template for:each={row.cells} for:item="cell">
-                                            <td key={cell.key} data-label={cell.key}>
-                                                <!-- title -->
-                                                <template if:true={cell.isTitle}>
-                                                    <a href={cell.url} target="_blank" rel="noopener" title="Open in Notion" class={cell.linkClass}>{cell.displayValue}</a>
-                                                </template>
-                                                <!-- plain text / number / date / created_by / last_edited_by / formula / rollup -->
-                                                <template if:true={cell.isText}>
-                                                    <span class="slds-truncate" title={cell.displayValue}>{cell.displayValue}</span>
-                                                </template>
-                                                <template if:true={cell.isNumber}>
-                                                    <span class="slds-truncate" title={cell.displayValue}>{cell.displayValue}</span>
-                                                </template>
-                                                <template if:true={cell.isDate}>
-                                                    <span class="slds-truncate" title={cell.displayValue}>{cell.displayValue}</span>
-                                                </template>
-                                                <!-- checkbox -->
-                                                <template if:true={cell.isCheckbox}>
-                                                    <template if:true={cell.boolValue}>
-                                                        <lightning-icon icon-name="utility:check" size="x-small" variant="success" alternative-text="Yes"></lightning-icon>
+                                            <td key={cell.key} role="gridcell" data-label={cell.key}>
+                                                <div class="slds-truncate" title={cell.displayValue}>
+                                                    <!-- title -->
+                                                    <template if:true={cell.isTitle}>
+                                                        <a href={cell.url} target="_blank" rel="noopener" class={cell.linkClass}>{cell.displayValue}</a>
                                                     </template>
-                                                    <template if:false={cell.boolValue}>
-                                                        <span class="slds-text-color_weak">—</span>
-                                                    </template>
-                                                </template>
-                                                <!-- single link (url / email / phone) -->
-                                                <template if:true={cell.isLink}>
-                                                    <template if:true={cell.url}>
-                                                        <a href={cell.url} target="_blank" rel="noopener">{cell.displayValue}</a>
-                                                    </template>
-                                                    <template if:false={cell.url}>
-                                                        <span>{cell.displayValue}</span>
-                                                    </template>
-                                                </template>
-                                                <!-- single badge (select / status) -->
-                                                <template if:true={cell.isBadge}>
-                                                    <template if:true={cell.displayValue}>
-                                                        <span class={cell.badgeClass}>{cell.displayValue}</span>
-                                                    </template>
-                                                </template>
-                                                <!-- multi badge (multi_select) -->
-                                                <template if:true={cell.isMultiBadge}>
-                                                    <template for:each={cell.items} for:item="it">
-                                                        <span key={it.key} class={it.badgeClass} style="margin-right:0.25rem;">{it.displayValue}</span>
-                                                    </template>
-                                                    <template if:true={cell.moreCount}>
-                                                        <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
-                                                    </template>
-                                                </template>
-                                                <!-- relation -->
-                                                <template if:true={cell.isLinkList}>
-                                                    <template for:each={cell.items} for:item="it">
-                                                        <a key={it.key} href={it.url} target="_blank" rel="noopener" class={it.linkClass}>{it.displayValue}</a>
-                                                    </template>
-                                                    <template if:true={cell.moreCount}>
-                                                        <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
-                                                    </template>
-                                                </template>
-                                                <!-- people -->
-                                                <template if:true={cell.isNameList}>
-                                                    <template for:each={cell.items} for:item="it">
-                                                        <span key={it.key} class="slds-m-right_xx-small">{it.displayValue}</span>
-                                                    </template>
-                                                    <template if:true={cell.moreCount}>
-                                                        <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
-                                                    </template>
-                                                </template>
-                                                <!-- files -->
-                                                <template if:true={cell.isFileList}>
-                                                    <template for:each={cell.items} for:item="it">
-                                                        <template if:true={it.url}>
-                                                            <a key={it.key} href={it.url} target="_blank" rel="noopener" class="slds-m-right_xx-small">{it.displayValue}</a>
+                                                    <!-- plain text / number / date / created_by / last_edited_by / formula / rollup -->
+                                                    <template if:true={cell.isText}>{cell.displayValue}</template>
+                                                    <template if:true={cell.isNumber}>{cell.displayValue}</template>
+                                                    <template if:true={cell.isDate}>{cell.displayValue}</template>
+                                                    <!-- checkbox -->
+                                                    <template if:true={cell.isCheckbox}>
+                                                        <template if:true={cell.boolValue}>
+                                                            <lightning-icon icon-name="utility:check" size="x-small" variant="success" alternative-text="Yes"></lightning-icon>
                                                         </template>
-                                                        <template if:false={it.url}>
-                                                            <span key={it.key} class="slds-m-right_xx-small">{it.displayValue}</span>
+                                                        <template if:false={cell.boolValue}>
+                                                            <span class="slds-text-color_weak">—</span>
                                                         </template>
                                                     </template>
-                                                    <template if:true={cell.moreCount}>
-                                                        <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                    <!-- single link (url / email / phone) -->
+                                                    <template if:true={cell.isLink}>
+                                                        <template if:true={cell.url}>
+                                                            <a href={cell.url} target="_blank" rel="noopener">{cell.displayValue}</a>
+                                                        </template>
+                                                        <template if:false={cell.url}>{cell.displayValue}</template>
                                                     </template>
-                                                </template>
+                                                    <!-- single badge (select / status) -->
+                                                    <template if:true={cell.isBadge}>
+                                                        <template if:true={cell.displayValue}>
+                                                            <span class={cell.badgeClass}>{cell.displayValue}</span>
+                                                        </template>
+                                                    </template>
+                                                    <!-- multi badge (multi_select) -->
+                                                    <template if:true={cell.isMultiBadge}>
+                                                        <template for:each={cell.items} for:item="it">
+                                                            <span key={it.key} class={it.badgeClass} style="margin-right:0.25rem;" title={it.displayValue}>{it.displayValue}</span>
+                                                        </template>
+                                                        <template if:true={cell.moreCount}>
+                                                            <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                        </template>
+                                                    </template>
+                                                    <!-- relation -->
+                                                    <template if:true={cell.isLinkList}>
+                                                        <template for:each={cell.items} for:item="it">
+                                                            <a key={it.key} href={it.url} target="_blank" rel="noopener" class={it.linkClass} title={it.displayValue}>{it.displayValue}</a>
+                                                        </template>
+                                                        <template if:true={cell.moreCount}>
+                                                            <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                        </template>
+                                                    </template>
+                                                    <!-- people -->
+                                                    <template if:true={cell.isNameList}>
+                                                        <template for:each={cell.items} for:item="it">
+                                                            <span key={it.key} class="slds-m-right_xx-small" title={it.displayValue}>{it.displayValue}</span>
+                                                        </template>
+                                                        <template if:true={cell.moreCount}>
+                                                            <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                        </template>
+                                                    </template>
+                                                    <!-- files -->
+                                                    <template if:true={cell.isFileList}>
+                                                        <template for:each={cell.items} for:item="it">
+                                                            <template if:true={it.url}>
+                                                                <a key={it.key} href={it.url} target="_blank" rel="noopener" class="slds-m-right_xx-small" title={it.displayValue}>{it.displayValue}</a>
+                                                            </template>
+                                                            <template if:false={it.url}>
+                                                                <span key={it.key} class="slds-m-right_xx-small" title={it.displayValue}>{it.displayValue}</span>
+                                                            </template>
+                                                        </template>
+                                                        <template if:true={cell.moreCount}>
+                                                            <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                        </template>
+                                                    </template>
+                                                </div>
                                             </td>
                                         </template>
                                     </tr>
@@ -178,7 +187,8 @@
                     </template>
                 </template>
 
-                <template if:false={hasData}>
+            <template if:false={hasData}>
+                <template if:false={isLoading}>
                     <div class="slds-p-around_medium slds-text-align_center slds-text-color_weak">
                         <lightning-icon icon-name="utility:info" size="small" class="slds-m-right_x-small"></lightning-icon>
                         {noDataMessage}

--- a/force-app/main/default/lwc/notionWidget/notionWidget.js
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.js
@@ -71,8 +71,18 @@ export default class NotionWidget extends LightningElement {
     @track sortProperty = null;
     @track sortDirection = null;
 
+    // Session-only column-width overrides keyed by propertyName.
+    // Reset on widget reload; not persisted to metadata.
+    @track resizedWidths = {};
+    _resizeState = null;
+
     connectedCallback() {
         this.loadWidget();
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener('mousemove', this._onResizeMove);
+        window.removeEventListener('mouseup', this._onResizeEnd);
     }
 
     async loadWidget() {
@@ -100,8 +110,10 @@ export default class NotionWidget extends LightningElement {
     }
 
     async loadFirstPage() {
-        // Wipe accumulated rows and pagination state, then fetch page 1.
-        this.rows = [];
+        // Reset pagination state but keep the existing rows visible during the
+        // fetch. Sort / refresh used to wipe the table to an empty spinner
+        // which felt jarring; we now overlay a spinner on top of the previous
+        // data and swap it in only when the new page arrives.
         this.nextCursor = null;
         this.hasMore = false;
         this.loadMoreError = null;
@@ -303,6 +315,38 @@ export default class NotionWidget extends LightningElement {
         this.loadFirstPage();
     }
 
+    // ---- Column resize (session only) ----
+    handleResizeStart = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const propertyName = event.currentTarget.dataset.property;
+        const th = event.currentTarget.closest('th');
+        if (!th) return;
+        this._resizeState = {
+            propertyName,
+            startX: event.clientX,
+            startWidth: th.getBoundingClientRect().width
+        };
+        window.addEventListener('mousemove', this._onResizeMove);
+        window.addEventListener('mouseup', this._onResizeEnd);
+    };
+
+    _onResizeMove = (event) => {
+        if (!this._resizeState) return;
+        const delta = event.clientX - this._resizeState.startX;
+        const newWidth = Math.max(40, Math.round(this._resizeState.startWidth + delta));
+        this.resizedWidths = {
+            ...this.resizedWidths,
+            [this._resizeState.propertyName]: newWidth
+        };
+    };
+
+    _onResizeEnd = () => {
+        window.removeEventListener('mousemove', this._onResizeMove);
+        window.removeEventListener('mouseup', this._onResizeEnd);
+        this._resizeState = null;
+    };
+
     async handleCreate() {
         if (this.isCreating) return;
         try {
@@ -353,6 +397,16 @@ export default class NotionWidget extends LightningElement {
         return this.rows && this.rows.length > 0;
     }
 
+    // Full-screen spinner only on the very first load (no rows yet).
+    // Subsequent sort / refresh shows an overlay spinner on top of the table.
+    get showInitialSpinner() {
+        return this.isLoading && !this.hasData;
+    }
+
+    get showRefreshOverlay() {
+        return this.isLoading && this.hasData;
+    }
+
     get widgetTitle() {
         return this.widgetConfig?.label || this.widgetDeveloperName || 'Notion Widget';
     }
@@ -361,15 +415,36 @@ export default class NotionWidget extends LightningElement {
         return this.columnDefs.map((col) => {
             const isSorted = this.sortProperty === col.propertyName;
             const direction = isSorted ? this.sortDirection : null;
+            const effectiveWidth = this.resizedWidths[col.propertyName] ?? col.width;
+            const ariaSort = col.sortable
+                ? (direction === 'ascending' ? 'ascending'
+                    : direction === 'descending' ? 'descending' : 'none')
+                : null;
+            // SLDS data table th classes — pairs `slds-is-sortable` with
+            // `slds-is-sorted` (+ direction) so the SLDS rule that hides
+            // `.slds-is-sortable__icon` flips on for sorted columns. Also
+            // adds `slds-is-resizable` so the divider handle gets SLDS styling.
+            const classes = ['slds-is-resizable'];
+            if (col.sortable) {
+                classes.push('slds-is-sortable');
+                if (direction === 'ascending') {
+                    classes.push('slds-is-sorted', 'slds-is-sorted_asc');
+                } else if (direction === 'descending') {
+                    classes.push('slds-is-sorted', 'slds-is-sorted_desc');
+                }
+            }
             return {
                 key: col.propertyName,
                 label: col.label || col.propertyName,
                 propertyName: col.propertyName,
                 isSortable: !!col.sortable,
-                width: col.width ? `width: ${col.width}px;` : '',
-                sortIcon: direction === 'ascending' ? 'utility:arrowup'
-                    : direction === 'descending' ? 'utility:arrowdown' : null,
-                hasSortIcon: !!direction
+                width: effectiveWidth ? `width: ${effectiveWidth}px;` : '',
+                ariaSort,
+                thClass: classes.join(' '),
+                // Always render an arrow icon; SLDS reveals it on hover when
+                // sortable, and keeps it visible when sorted. Direction
+                // controls which way the arrow points.
+                sortIcon: direction === 'ascending' ? 'utility:arrowup' : 'utility:arrowdown'
             };
         });
     }


### PR DESCRIPTION
## Summary
Refactors the runtime widget LWC to use canonical SLDS data table markup and brings the look-and-feel in line with Salesforce's native related lists, plus a few small UX additions.

### Markup / SLDS compliance
- `<table>` now uses `role="grid"` + `slds-table_resizable-cols` (dropped `slds-table_cell-buffer`, which conflicted with `resizable-cols` and gave the first column an extra 1.5rem padding that prevented `.slds-th__action` from filling the cell on hover).
- `<th>` carries `slds-is-sortable` / `slds-is-sorted` / `slds-is-sorted_asc|desc` / `slds-is-resizable` so SLDS' built-in styling drives the sort icon visibility and divider visuals.
- Sortable header uses canonical `<a class="slds-th__action"><span class="slds-assistive-text">Sort by:</span><div class="slds-grid slds-grid_vertical-align-center slds-has-flexi-truncate">label + icon</div></a>`.
- Non-sortable header switched from a bare `slds-truncate` div to the same `<div class="slds-th__action">` wrapper so it gets the canonical 0.5rem inner padding instead of sitting flush against the cell border.
- Each `<td role="gridcell">` wraps its content in `<div class="slds-truncate" title={displayValue}>` so SLDS handles ellipsis truncation natively.
- Resize control uses canonical `<div class="slds-resizable"><input type="range" class="slds-resizable__input slds-assistive-text"/><span class="slds-resizable__handle"><span class="slds-resizable__divider"></span></span></div>`.
- Dropped all custom CSS that had been working around the lack of the above (`notion-widget-th` relative positioning, `.slds-resizable` absolute override, `.slds-th__action` `display: inline-flex` override, `td { overflow: hidden }`, `td > a/span` inline-block stretch).

### New behavior
- Column resize via drag handle on header edges (session-only — not persisted to metadata).
- Sort / refresh now keeps the previous rows visible and overlays a spinner instead of wiping the table to an empty spinner state.
- Every cell value (title link, badges, multi-value items, etc.) now carries `title={displayValue}` so the full text shows on hover when the column is too narrow to display it.

### Other tweaks
- "New" button switched from `variant="brand"` + add icon to `variant="neutral"` with no icon, matching native related list affordance.
- Button order in the card actions is now refresh -> New (was New -> refresh).
- Wrapper sets `overflow-y: hidden` explicitly so the browser doesn't promote `overflow-x: auto` into a stray vertical scrollbar.

## Test plan
- [x] Manually verified in the scratch org: Test Child Records widget renders with proper SLDS data table appearance — column hover highlights the full cell (`<a class="slds-th__action">` `offsetWidth === <th>.offsetWidth`), non-sortable headers no longer touch the border, button order matches native, sort/refresh preserves rows under an overlay spinner, drag-resize works on the column edges.
- [x] Existing Apex unit tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)