### PR TITLE
fix: Polish widget header title and sort icon direction

### DIFF
--- a/force-app/main/default/lwc/notionWidget/notionWidget.js
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.js
@@ -408,7 +408,7 @@ export default class NotionWidget extends LightningElement {
     }
 
     get widgetTitle() {
-        return this.widgetConfig?.label || this.widgetDeveloperName || 'Notion Widget';
+        return this.widgetConfig?.label || '';
     }
 
     get headerColumns() {
@@ -420,18 +420,21 @@ export default class NotionWidget extends LightningElement {
                 ? (direction === 'ascending' ? 'ascending'
                     : direction === 'descending' ? 'descending' : 'none')
                 : null;
-            // SLDS data table th classes — pairs `slds-is-sortable` with
-            // `slds-is-sorted` (+ direction) so the SLDS rule that hides
-            // `.slds-is-sortable__icon` flips on for sorted columns. Also
-            // adds `slds-is-resizable` so the divider handle gets SLDS styling.
+            // SLDS data table th classes. Native lightning-datatable applies
+            // `slds-is-sorted_asc` even on unsorted-but-sortable columns so
+            // that the hover preview of the sort icon points up — matching
+            // the direction the first click will take (ascending). Without
+            // `slds-is-sorted` the icon stays hidden until hovered (SLDS only
+            // promotes it to inline-block on `:hover` or when sorted).
             const classes = ['slds-is-resizable'];
             if (col.sortable) {
                 classes.push('slds-is-sortable');
-                if (direction === 'ascending') {
-                    classes.push('slds-is-sorted', 'slds-is-sorted_asc');
-                } else if (direction === 'descending') {
-                    classes.push('slds-is-sorted', 'slds-is-sorted_desc');
+                if (direction !== null) {
+                    classes.push('slds-is-sorted');
                 }
+                classes.push(direction === 'descending'
+                    ? 'slds-is-sorted_desc'
+                    : 'slds-is-sorted_asc');
             }
             return {
                 key: col.propertyName,
@@ -441,10 +444,11 @@ export default class NotionWidget extends LightningElement {
                 width: effectiveWidth ? `width: ${effectiveWidth}px;` : '',
                 ariaSort,
                 thClass: classes.join(' '),
-                // Always render an arrow icon; SLDS reveals it on hover when
-                // sortable, and keeps it visible when sorted. Direction
-                // controls which way the arrow points.
-                sortIcon: direction === 'ascending' ? 'utility:arrowup' : 'utility:arrowdown'
+                // SLDS data-table convention: icon-name stays fixed
+                // (`utility:arrowdown`) and SLDS rotates it 180deg via the
+                // `slds-is-sorted_asc` class on the <th>. Switching icon-name
+                // dynamically here cancels out that rotation.
+                sortIcon: 'utility:arrowdown'
             };
         });
     }


### PR DESCRIPTION
## Summary

Two small follow-ups to the related-list-style widget polish merged in #101:

- **Widget title flash** — During the initial load, the card title briefly showed the metadata Developer Name (e.g. `Account_Contacts`) before the configured label arrived. The Developer Name is an internal identifier and shouldn't leak to end users, so the title now stays empty until `widgetConfig.label` resolves.

- **Sort icon direction** — Two issues, fixed together because they share the same getter:
  - Ascending state was rendering as a ↓ arrow. We were swapping `icon-name` between `utility:arrowup`/`utility:arrowdown` based on direction, but SLDS already applies a 180° CSS rotation when `slds-is-sorted_asc` is on the `<th>`. The two effects cancelled out. Switched to the SLDS canonical pattern: `icon-name` stays fixed at `utility:arrowdown` and SLDS handles rotation via class.
  - Hover preview on an unsorted column pointed in the opposite direction of the first click (showed ↓, but clicking went to ascending). Native `lightning-datatable` solves this by applying `slds-is-sorted_asc` to unsorted-but-sortable columns too, so the on-hover icon points up to preview the ascending first-click. Adopted the same pattern.

## Test plan

- [x] Verified in scratch org with a widget on `Test_Parent_Object__c` record page
- [x] Initial load — title shows blank then \"Test Child Records\" (label); never shows `Test_Child_Records` (developer name)
- [x] Descending sorted column shows ↓
- [x] Click sorted-descending column → ascending, icon flips to ↑
- [x] Hover an unsorted sortable column — icon appears as ↑ (matches the first-click ascending direction)
- [x] Click unsorted sortable column → sorts ascending, icon visibly ↑

🤖 Generated with [Claude Code](https://claude.com/claude-code)