### PR TITLE
Unify Notion Sync Admin UI controls and variants

### DIFF
--- a/force-app/integration/default/customMetadata/NotionWidgetColumn.Test_Child_Records_Assignees.md-meta.xml
+++ b/force-app/integration/default/customMetadata/NotionWidgetColumn.Test_Child_Records_Assignees.md-meta.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Assignees</label>
+    <protected>false</protected>
+    <values>
+        <field>DisplayOrder__c</field>
+        <value xsi:type="xsd:double">4.0</value>
+    </values>
+    <values>
+        <field>IsSortable__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsVisible__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>NotionPropertyName__c</field>
+        <value xsi:type="xsd:string">Assignees</value>
+    </values>
+    <values>
+        <field>NotionPropertyType__c</field>
+        <value xsi:type="xsd:string">people</value>
+    </values>
+    <values>
+        <field>NotionWidget__c</field>
+        <value xsi:type="xsd:string">Test_Child_Records</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/lwc/notionFieldMapping/notionFieldMapping.html
+++ b/force-app/main/default/lwc/notionFieldMapping/notionFieldMapping.html
@@ -84,28 +84,26 @@
                 
                 <div class="slds-grid slds-gutters">
                     <div class="slds-col slds-size_1-of-2">
-                        <lightning-combobox
-                            name="field"
+                        <c-searchable-combobox
                             label="Salesforce Field"
                             value={newMapping.salesforceFieldApiName}
                             placeholder="Select a field"
                             options={availableFields}
                             onchange={handleFieldSelection}
                             required
-                        ></lightning-combobox>
+                        ></c-searchable-combobox>
                     </div>
-                    
+
                     <div class="slds-col slds-size_1-of-2">
                         <template if:false={newMapping.isBodyContent}>
-                            <lightning-combobox
-                                name="property"
+                            <c-searchable-combobox
                                 label="Notion Property"
                                 value={newMapping.notionPropertyName}
                                 placeholder="Select a property"
                                 options={availableProperties}
                                 onchange={handlePropertySelection}
                                 required
-                            ></lightning-combobox>
+                            ></c-searchable-combobox>
                         </template>
                         <template if:true={newMapping.isBodyContent}>
                             <div class="slds-form-element">
@@ -137,7 +135,6 @@
                         ></lightning-button>
                         <lightning-button
                             label="Add Mapping"
-                            variant="brand"
                             onclick={handleAddMapping}
                         ></lightning-button>
                     </lightning-button-group>

--- a/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.html
+++ b/force-app/main/default/lwc/notionRelationshipConfig/notionRelationshipConfig.html
@@ -86,21 +86,19 @@
                         
                         <div class="slds-grid slds-gutters slds-m-bottom_small">
                             <div class={fieldColumnClass}>
-                                <lightning-combobox
-                                    name="field"
+                                <c-searchable-combobox
                                     label="Salesforce Relationship Field"
                                     value={newMapping.salesforceRelationshipField}
                                     placeholder="Select a relationship field"
                                     options={availableRelationshipFields}
                                     onchange={handleFieldSelection}
                                     required
-                                ></lightning-combobox>
+                                ></c-searchable-combobox>
                             </div>
                             
                             <template if:true={showTargetObjectSelector}>
                                 <div class={targetObjectColumnClass}>
-                                    <lightning-combobox
-                                        name="targetObject"
+                                    <c-searchable-combobox
                                         label="Target Sync Object"
                                         value={newMapping.parentObject}
                                         placeholder="Select target object"
@@ -108,13 +106,12 @@
                                         onchange={handleTargetObjectSelection}
                                         required
                                         disabled={isTargetObjectDisabled}
-                                    ></lightning-combobox>
+                                    ></c-searchable-combobox>
                                 </div>
                             </template>
                             
                             <div class={propertyColumnClass}>
-                                <lightning-combobox
-                                    name="property"
+                                <c-searchable-combobox
                                     label="Notion Relation Property"
                                     value={newMapping.notionRelationPropertyName}
                                     placeholder="Select a relation property"
@@ -122,7 +119,7 @@
                                     onchange={handlePropertySelection}
                                     required
                                     disabled={isNotionPropertyDisabled}
-                                ></lightning-combobox>
+                                ></c-searchable-combobox>
                             </div>
                         </div>
 
@@ -142,7 +139,6 @@
                                 ></lightning-button>
                                 <lightning-button
                                     label="Add Mapping"
-                                    variant="brand"
                                     onclick={handleSaveNewMapping}
                                     disabled={isSaveDisabled}
                                 ></lightning-button>

--- a/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
+++ b/force-app/main/default/lwc/notionSyncAdmin/notionSyncAdmin.html
@@ -105,31 +105,24 @@
                 <template if:true={isConfigurationView}>
                     <div class="slds-p-around_medium">
                         <!-- Back Button and Title -->
-                        <div class="slds-grid slds-grid_align-spread slds-m-bottom_medium">
-                            <div class="slds-col">
-                                <div class="slds-media slds-media_center">
-                                    <div class="slds-media__figure">
-                                        <lightning-button-icon
-                                            icon-name="utility:back"
-                                            alternative-text="Back"
-                                            onclick={handleBack}
-                                        ></lightning-button-icon>
-                                    </div>
-                                    <div class="slds-media__body">
-                                        <h2 class="slds-text-heading_medium">
-                                            {configurationTitle}
-                                            <template if:true={currentConfiguration}>
-                                                <template if:true={currentConfiguration.isActive}>
-                                                    <lightning-badge label="Active" variant="success" class="slds-m-left_x-small"></lightning-badge>
-                                                </template>
-                                                <template if:false={currentConfiguration.isActive}>
-                                                    <lightning-badge label="Inactive" class="slds-m-left_x-small"></lightning-badge>
-                                                </template>
-                                            </template>
-                                        </h2>
-                                    </div>
-                                </div>
-                            </div>
+                        <div class="slds-m-bottom_medium">
+                            <lightning-button
+                                label="Back to List"
+                                icon-name="utility:back"
+                                onclick={handleBack}
+                                variant="base"
+                            ></lightning-button>
+                            <h2 class="slds-text-heading_medium slds-m-top_small">
+                                {configurationTitle}
+                                <template if:true={currentConfiguration}>
+                                    <template if:true={currentConfiguration.isActive}>
+                                        <lightning-badge label="Active" variant="success" class="slds-m-left_x-small"></lightning-badge>
+                                    </template>
+                                    <template if:false={currentConfiguration.isActive}>
+                                        <lightning-badge label="Inactive" class="slds-m-left_x-small"></lightning-badge>
+                                    </template>
+                                </template>
+                            </h2>
                         </div>
 
                         <!-- Configuration Form -->
@@ -148,8 +141,7 @@
                                 
                                 <!-- Salesforce Object Selection (for new configs) -->
                                 <template if:true={showObjectSelection}>
-                                    <lightning-combobox
-                                        name="object"
+                                    <c-searchable-combobox
                                         label="Select Salesforce Object"
                                         value={selectedObject}
                                         placeholder="Choose an object to configure"
@@ -157,7 +149,7 @@
                                         onchange={handleObjectSelection}
                                         required
                                         class="slds-m-bottom_small"
-                                    ></lightning-combobox>
+                                    ></c-searchable-combobox>
                                 </template>
                                 
                                 <!-- Salesforce Object Info (for existing configs) -->
@@ -185,7 +177,6 @@
                                         <lightning-button
                                             label="Browse Databases"
                                             onclick={handleShowDatabaseBrowser}
-                                            variant="brand"
                                         ></lightning-button>
                                     </div>
                                 </div>

--- a/force-app/main/default/lwc/notionWidget/notionWidget.html
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.html
@@ -130,11 +130,9 @@
                                                     </template>
                                                     <!-- people -->
                                                     <template if:true={cell.isNameList}>
-                                                        <template for:each={cell.items} for:item="it">
-                                                            <span key={it.key} class="slds-m-right_xx-small" title={it.displayValue}>{it.displayValue}</span>
-                                                        </template>
+                                                        {cell.displayValue}
                                                         <template if:true={cell.moreCount}>
-                                                            <span class="slds-text-color_weak slds-text-body_small">+{cell.moreCount} more</span>
+                                                            <span class="slds-text-color_weak slds-text-body_small">  +{cell.moreCount} more</span>
                                                         </template>
                                                     </template>
                                                     <!-- files -->

--- a/force-app/main/default/lwc/notionWidget/notionWidget.js
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.js
@@ -271,6 +271,10 @@ export default class NotionWidget extends LightningElement {
                 break;
             case RENDER_KIND.NAME_LIST:
                 cell.isNameList = true;
+                // People names render as a single comma-separated string;
+                // recompute from the (server-capped) items list so the visible
+                // text always agrees with the `+N more` overflow count below.
+                cell.displayValue = cell.items.map((it) => it.displayValue).join(', ');
                 break;
             case RENDER_KIND.FILE_LIST:
                 cell.isFileList = true;

--- a/force-app/main/default/lwc/notionWidgetColumnConfigurator/notionWidgetColumnConfigurator.html
+++ b/force-app/main/default/lwc/notionWidgetColumnConfigurator/notionWidgetColumnConfigurator.html
@@ -191,15 +191,14 @@
             <div class="slds-box slds-m-top_small">
                 <h4 class="slds-text-heading_small slds-m-bottom_small">Add Column</h4>
 
-                <lightning-combobox
-                    name="property"
+                <c-searchable-combobox
                     label="Select Property"
                     value={selectedPropertyForAdd}
                     placeholder="Choose a Notion property"
                     options={availableProperties}
                     onchange={handlePropertySelection}
                     required
-                ></lightning-combobox>
+                ></c-searchable-combobox>
 
                 <div class="slds-m-top_medium">
                     <lightning-button-group>
@@ -209,7 +208,6 @@
                         ></lightning-button>
                         <lightning-button
                             label="Add Column"
-                            variant="brand"
                             onclick={handleAddColumn}
                             disabled={noSelectedPropertyForAdd}
                         ></lightning-button>

--- a/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.html
+++ b/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.html
@@ -1,6 +1,8 @@
 <template>
-    <!-- Loading Overlay -->
-    <template if:true={isLoading}>
+    <!-- Loading Overlay (for non-modal contexts; the modal renders its own
+         positioned spinner inside slds-modal__content so it stays within the
+         dialog rather than overlaying the page behind it). -->
+    <template if:true={showTopLevelSpinner}>
         <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
     </template>
 
@@ -233,7 +235,7 @@
                             ></lightning-combobox>
                         </div>
                         <div class="slds-col slds-size_1-of-3">
-                            <lightning-combobox
+                            <c-searchable-combobox
                                 label="Default Sort Property"
                                 value={editingWidget.defaultSortProperty}
                                 options={sortPropertyOptions}
@@ -241,7 +243,7 @@
                                 onchange={handleInputChange}
                                 placeholder="Select property"
                                 disabled={noNotionProperties}
-                            ></lightning-combobox>
+                            ></c-searchable-combobox>
                         </div>
                         <div class="slds-col slds-size_1-of-3">
                             <lightning-combobox
@@ -264,20 +266,20 @@
                 <div class="slds-card__body slds-card__body_inner">
                     <div class="slds-grid slds-gutters slds-wrap">
                         <div class="slds-col slds-size_1-of-2">
-                            <lightning-combobox
+                            <c-searchable-combobox
                                 label="Context Object"
                                 value={editingWidget.contextObjectApiName}
                                 options={contextObjectOptions}
                                 data-field="contextObjectApiName"
                                 onchange={handleInputChange}
-                                placeholder="(none)"
-                            ></lightning-combobox>
+                                placeholder="(none) — type to search by label or API name"
+                            ></c-searchable-combobox>
                             <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
                                 Set this to enable context field filters and the relation property below.
                             </div>
                         </div>
                         <div class="slds-col slds-size_1-of-2">
-                            <lightning-combobox
+                            <c-searchable-combobox
                                 label="Context Relation Property"
                                 value={editingWidget.contextRelationProperty}
                                 options={relationPropertyOptions}
@@ -285,7 +287,7 @@
                                 onchange={handleInputChange}
                                 placeholder="(none)"
                                 disabled={noNotionProperties}
-                            ></lightning-combobox>
+                            ></c-searchable-combobox>
                             <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
                                 When set, the widget acts as a related list: rows are filtered to those whose relation includes the context Notion page, and new pages auto-set this relation.
                             </div>
@@ -373,7 +375,10 @@
                     ></lightning-button-icon>
                     <h2 class="slds-modal__title">Select Notion Database</h2>
                 </header>
-                <div class="slds-modal__content slds-p-around_medium">
+                <div class="slds-modal__content slds-p-around_medium slds-is-relative">
+                    <template if:true={isLoading}>
+                        <lightning-spinner alternative-text="Loading" size="medium"></lightning-spinner>
+                    </template>
                     <!-- Search -->
                     <lightning-input
                         type="search"

--- a/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.js
+++ b/force-app/main/default/lwc/notionWidgetDesigner/notionWidgetDesigner.js
@@ -212,6 +212,13 @@ export default class NotionWidgetDesigner extends LightningElement {
         return this.currentView === 'selectDatabase';
     }
 
+    // Suppress the top-level loading overlay while the database-selector
+    // modal is open — the modal renders its own positioned spinner so the
+    // top-level one would otherwise appear to "leak" outside the dialog.
+    get showTopLevelSpinner() {
+        return this.isLoading && !this.showDatabaseSelector;
+    }
+
     get hasWidgets() {
         return this.widgets && this.widgets.length > 0;
     }

--- a/force-app/main/default/lwc/notionWidgetFilterBuilder/notionWidgetFilterBuilder.html
+++ b/force-app/main/default/lwc/notionWidgetFilterBuilder/notionWidgetFilterBuilder.html
@@ -119,15 +119,14 @@
 
                 <!-- Property selection -->
                 <div class="slds-m-bottom_small">
-                    <lightning-combobox
-                        name="property"
+                    <c-searchable-combobox
                         label="Property"
                         value={newFilter.propertyName}
                         placeholder="Select a Notion property"
                         options={propertyOptions}
                         onchange={handlePropertyChange}
                         required
-                    ></lightning-combobox>
+                    ></c-searchable-combobox>
                 </div>
 
                 <!-- Operator selection -->
@@ -172,14 +171,13 @@
                 <template if:true={showNewFilterContextField}>
                     <template if:true={hasContextFields}>
                         <div class="slds-m-bottom_small">
-                            <lightning-combobox
-                                name="contextField"
+                            <c-searchable-combobox
                                 label="Context Record Field"
                                 value={newFilter.contextField}
                                 placeholder="Select a Salesforce field"
                                 options={contextFieldOptions}
                                 onchange={handleContextFieldChange}
-                            ></lightning-combobox>
+                            ></c-searchable-combobox>
                             <div class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
                                 The filter will use the value from this field on the current record.
                             </div>
@@ -202,7 +200,6 @@
                         ></lightning-button>
                         <lightning-button
                             label="Add Filter"
-                            variant="brand"
                             onclick={handleAddFilter}
                             disabled={cannotAddFilter}
                         ></lightning-button>

--- a/force-app/main/default/lwc/searchableCombobox/searchableCombobox.html
+++ b/force-app/main/default/lwc/searchableCombobox/searchableCombobox.html
@@ -1,0 +1,82 @@
+<template>
+    <div class="slds-form-element">
+        <template if:true={label}>
+            <label class="slds-form-element__label" for="combobox-input">
+                <template if:true={required}>
+                    <abbr class="slds-required" title="required">* </abbr>
+                </template>
+                {label}
+            </label>
+        </template>
+        <div class="slds-form-element__control">
+            <div class={comboboxContainerClass}>
+                <div class="slds-combobox_container">
+                    <div class={comboboxClass} aria-expanded={isOpen} aria-haspopup="listbox" role="combobox">
+                        <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right" role="none">
+                            <input
+                                type="text"
+                                id="combobox-input"
+                                class="slds-input slds-combobox__input"
+                                aria-autocomplete="list"
+                                aria-controls="combobox-listbox"
+                                autocomplete="off"
+                                role="textbox"
+                                placeholder={placeholder}
+                                value={inputValue}
+                                disabled={disabled}
+                                onfocus={handleFocus}
+                                oninput={handleInput}
+                                onkeydown={handleKeydown}
+                                onblur={handleBlur}
+                            />
+                            <lightning-icon
+                                icon-name="utility:down"
+                                size="x-small"
+                                class="slds-input__icon slds-input__icon_right"
+                                alternative-text="Open dropdown"
+                            ></lightning-icon>
+                        </div>
+                        <div
+                            id="combobox-listbox"
+                            class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-with-icon-7"
+                            role="listbox"
+                            if:true={isOpen}
+                        >
+                            <template if:true={hasMatches}>
+                                <ul class="slds-listbox slds-listbox_vertical" role="presentation">
+                                    <template for:each={visibleOptions} for:item="opt">
+                                        <li
+                                            key={opt.value}
+                                            role="presentation"
+                                            class="slds-listbox__item"
+                                        >
+                                            <div
+                                                class={opt.itemClass}
+                                                role="option"
+                                                aria-selected={opt.ariaSelected}
+                                                data-value={opt.value}
+                                                onmousedown={handleOptionMouseDown}
+                                            >
+                                                <span class="slds-media__body">
+                                                    <span class="slds-listbox__option-text slds-listbox__option-text_entity">{opt.label}</span>
+                                                </span>
+                                            </div>
+                                        </li>
+                                    </template>
+                                </ul>
+                            </template>
+                            <template if:false={hasMatches}>
+                                <div class="slds-p-around_small slds-text-color_weak slds-text-body_small">
+                                    No matches
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <template if:true={fieldLevelHelp}>
+            <div class="slds-form-element__help">{fieldLevelHelp}</div>
+        </template>
+    </div>
+</template>

--- a/force-app/main/default/lwc/searchableCombobox/searchableCombobox.js
+++ b/force-app/main/default/lwc/searchableCombobox/searchableCombobox.js
@@ -1,0 +1,167 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class SearchableCombobox extends LightningElement {
+    @api label;
+    @api placeholder = '';
+    @api fieldLevelHelp;
+    @api disabled = false;
+    @api required = false;
+
+    _options = [];
+    _value = '';
+
+    @track inputValue = '';
+    @track query = '';
+    @track isOpen = false;
+    @track activeIndex = -1;
+
+    @api
+    get options() {
+        return this._options;
+    }
+    set options(value) {
+        this._options = Array.isArray(value) ? value : [];
+        this.syncInputFromValue();
+    }
+
+    @api
+    get value() {
+        return this._value;
+    }
+    set value(v) {
+        this._value = v == null ? '' : String(v);
+        this.syncInputFromValue();
+    }
+
+    syncInputFromValue() {
+        const match = this._options.find((o) => o.value === this._value);
+        const newLabel = match ? match.label : '';
+        if (!this.isOpen) {
+            this.inputValue = newLabel;
+            this.query = '';
+        }
+    }
+
+    get visibleOptions() {
+        const q = (this.query || '').toLowerCase();
+        const filtered = q
+            ? this._options.filter((o) => (o.label || '').toLowerCase().includes(q))
+            : this._options.slice();
+        return filtered.map((o, idx) => ({
+            value: o.value,
+            label: o.label,
+            ariaSelected: o.value === this._value ? 'true' : 'false',
+            itemClass: this.optionClass(o.value === this._value, idx === this.activeIndex)
+        }));
+    }
+
+    get hasMatches() {
+        return this.visibleOptions.length > 0;
+    }
+
+    get comboboxContainerClass() {
+        return 'slds-combobox_container';
+    }
+
+    get comboboxClass() {
+        return `slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click${
+            this.isOpen ? ' slds-is-open' : ''
+        }`;
+    }
+
+    optionClass(isSelected, isActive) {
+        const base = 'slds-media slds-listbox__option slds-listbox__option_plain slds-media_small';
+        const focusClass = isActive ? ' slds-has-focus' : '';
+        const selectedClass = isSelected ? ' slds-is-selected' : '';
+        return base + focusClass + selectedClass;
+    }
+
+    handleFocus() {
+        if (this.disabled) return;
+        this.openDropdown();
+    }
+
+    openDropdown() {
+        this.isOpen = true;
+        // When opening, clear the input so the user sees all options (and
+        // can start typing to filter). The current selection still shows
+        // as highlighted in the list.
+        this.query = '';
+        this.inputValue = '';
+        this.activeIndex = -1;
+    }
+
+    closeDropdown() {
+        this.isOpen = false;
+        this.activeIndex = -1;
+        this.syncInputFromValue();
+    }
+
+    handleInput(event) {
+        this.query = event.target.value;
+        this.inputValue = event.target.value;
+        this.isOpen = true;
+        this.activeIndex = -1;
+    }
+
+    handleKeydown(event) {
+        const visible = this.visibleOptions;
+        switch (event.key) {
+            case 'ArrowDown':
+                event.preventDefault();
+                if (!this.isOpen) {
+                    this.openDropdown();
+                    return;
+                }
+                this.activeIndex = Math.min(this.activeIndex + 1, visible.length - 1);
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                if (this.isOpen) {
+                    this.activeIndex = Math.max(this.activeIndex - 1, 0);
+                }
+                break;
+            case 'Enter':
+                if (this.isOpen && this.activeIndex >= 0 && this.activeIndex < visible.length) {
+                    event.preventDefault();
+                    this.commitSelection(visible[this.activeIndex].value);
+                }
+                break;
+            case 'Escape':
+                if (this.isOpen) {
+                    event.preventDefault();
+                    this.closeDropdown();
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    // Use mousedown (not click) so the option is committed before the input's
+    // blur event fires and collapses the dropdown.
+    handleOptionMouseDown(event) {
+        event.preventDefault();
+        const value = event.currentTarget.dataset.value;
+        this.commitSelection(value);
+    }
+
+    handleBlur() {
+        // Defer to allow option mousedown to be processed first.
+        setTimeout(() => {
+            this.closeDropdown();
+        }, 0);
+    }
+
+    commitSelection(value) {
+        this._value = value;
+        this.syncInputFromValue();
+        this.isOpen = false;
+        this.activeIndex = -1;
+        this.dispatchEvent(
+            new CustomEvent('change', {
+                detail: { value }
+            })
+        );
+    }
+}

--- a/force-app/main/default/lwc/searchableCombobox/searchableCombobox.js-meta.xml
+++ b/force-app/main/default/lwc/searchableCombobox/searchableCombobox.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary

Two follow-ups based on UX review of the Notion Sync Admin:

1. **People column display** — Each assignee was rendered in its own `<span>` with no separator, so multiple names ran together (`"Foo BarBaz"`). Since people are plain text (no per-item visual affordance), render them as one comma-joined string for readability and keep the `+N more` overflow.

2. **Admin UI consistency** — Several mismatches were called out across the Sync and Widget screens. Adopt one set of rules:
   - **Searchable combobox** for data-driven (object / field / Notion property) selectors. The Context Object dropdown alone had ~400 entries with no filter. Introduce a new `c-searchable-combobox` LWC (SLDS combobox markup + substring filter on the displayed label, which already concatenates label and API name) and apply it across Sync admin / Relationship config / Field mapping / Filter builder / Column configurator / Widget designer. Static enums (operator, AND/OR, asc/desc, page size, property type) keep `lightning-combobox`.
   - **Back navigation parity** — Sync admin used a bare `lightning-button-icon` (chevron only), Widget designer used a labelled `lightning-button variant=\"base\"`. Standardize on the labelled form (\"Back to List\" + icon).
   - **Brand button discipline** — One `variant=\"brand\"` per view, reserved for the primary CTA. Downgrade five inline-form actions to neutral (Add Mapping / Add Column / Add Filter / Add Mapping in relationship config / Browse Databases on sync edit).
   - **Modal loading spinner placement** — The top-level overlay leaked outside the database-selector dialog. Add `slds-is-relative` + a spinner inside `slds-modal__content`, and suppress the top-level spinner while that modal is open via a `showTopLevelSpinner` getter.

## Test plan

- [x] Hard-reload scratch org; widget runtime now shows people as \"Foo, Bar, Baz, Qux\" with trailing \"+N more\" once capped
- [x] Context Object dropdown filters by typing (label and API name both match), keyboard arrow/Enter selects, blur restores label
- [x] Sync admin and Widget designer subpage headers both render \"← Back to List\" in the same place / variant
- [x] Brand-coloured buttons remaining: New Sync Configuration, New Widget, Save Widget, Save, Select Database (modal confirm)
- [x] All searchable combobox replacements still dispatch the original `change` event shape (`event.detail.value`), so existing handlers work without modification
- [x] Loading spinner now appears inside the database selector dialog rather than behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)