### PR TITLE
fix: Let widget viewers load widget configuration

### DIFF
--- a/force-app/main/default/classes/NotionWidgetController.cls
+++ b/force-app/main/default/classes/NotionWidgetController.cls
@@ -156,11 +156,17 @@ public with sharing class NotionWidgetController {
     }
 
     /**
-     * Get widget configuration for designer
+     * Get widget configuration.
+     *
+     * Used by both the widget runtime (notionWidget LWC) at render time and by
+     * the designer when loading an existing config for edit. No admin
+     * permission check here — runtime users only need read access to the
+     * widget metadata, which the `Notion_Widget_User` permission set already
+     * grants. Designer access itself is gated by app / tab visibility on
+     * `Notion_Sync_Admin`.
      */
     @AuraEnabled(cacheable=true)
     public static WidgetConfiguration getWidgetConfiguration(String widgetDeveloperName) {
-        checkAdminPermission();
         try {
             NotionWidget__mdt widget = getWidgetMetadata(widgetDeveloperName);
             if (widget == null) {


### PR DESCRIPTION
## Summary

Users with only the `Notion_Widget_User` permission set (widget viewers, not configurators) saw \"You don't have permission to manage Notion Widget configurations\" the moment a Lightning page containing a Notion Widget loaded.

`getWidgetConfiguration` is the very first Apex call the widget runtime makes — it fetches the configured columns, title, page size, default sort etc. before any data is requested. The method was gated by `checkAdminPermission()`, which throws when the user lacks `Notion_Sync_Admin`, so the page failed on render.

Drop the admin check on this single read-only method. The configurator UI is still protected (it's reached through navigation / tab access guarded by `Notion_Sync_Admin`), and the four mutation / metadata-listing methods (`getAllWidgetConfigurations`, `saveWidgetConfiguration`, `deleteWidgetConfiguration`, `getContextFilterableFields`) keep the admin check. `Notion_Widget_User` already grants read access to the underlying `NotionWidget__mdt` / `NotionWidgetColumn__mdt` / `NotionWidgetFilter__mdt` CMTs that this method queries.

## Test plan

- [x] Assign only `Notion_Widget_User` (not `Notion_Sync_Admin`) to a user
- [x] Open a Lightning record page that hosts a Notion Widget — config loads, widget renders rows
- [x] Confirm an admin-only user (no `Notion_Sync_Admin`) still gets a permission error when navigating to the Notion Sync Admin tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)