### PR TITLE
feat: Use Notion-style logo icon in notionWidget and notionNavigation

### DIFF
--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.css
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.css
@@ -1,0 +1,7 @@
+/* Notion-N logo shown in place of the default SLDS card icon. Sized to
+   match the standard SLDS card header icon (1.5rem square). */
+.notion-card-icon-img {
+    width: 1.5rem;
+    height: 1.5rem;
+    vertical-align: middle;
+}

--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.html
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.html
@@ -1,5 +1,11 @@
 <template>
-    <lightning-card title="Notion Navigation" icon-name="custom:custom19">
+    <lightning-card>
+        <h2 slot="title" class="slds-card__header-title">
+            <span class="slds-icon_container slds-m-right_x-small notion-card-icon">
+                <img src={notionLogoUrl} alt="Notion" class="notion-card-icon-img"/>
+            </span>
+            <span class="slds-truncate" title="Notion Navigation">Notion Navigation</span>
+        </h2>
         <div class="slds-p-horizontal_medium">
             <!-- Loading State -->
             <template if:true={isLoading}>

--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.js
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.js
@@ -1,5 +1,6 @@
 import { LightningElement, api, wire } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import notionLogo from '@salesforce/resourceUrl/NotionLogo';
 import getNotionPageInfo from '@salesforce/apex/NotionNavigationController.getNotionPageInfo';
 import syncAndGetNotionPage from '@salesforce/apex/NotionNavigationController.syncAndGetNotionPage';
 
@@ -8,6 +9,10 @@ export default class NotionNavigation extends LightningElement {
     @api objectApiName;
     @api autoRedirect;
     @api showSyncOption;
+
+    get notionLogoUrl() {
+        return notionLogo;
+    }
     
     notionUrl = null;
     loading = true;

--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.svg
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="3" y="3" width="94" height="94" rx="16" fill="#FFFFFF" stroke="#000000" stroke-width="6"/>
+  <path d="M25 25 V75 H38 V45 L62 75 H75 V25 H62 V55 L38 25 Z" fill="#000000"/>
+</svg>

--- a/force-app/main/default/lwc/notionWidget/notionWidget.css
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.css
@@ -2,6 +2,14 @@
     display: block;
 }
 
+/* Notion-N logo shown in place of the default SLDS card icon. Sized to
+   match the standard SLDS card header icon (1.5rem square). */
+.notion-card-icon-img {
+    width: 1.5rem;
+    height: 1.5rem;
+    vertical-align: middle;
+}
+
 .notion-widget-table-wrapper {
     /* Per CSS spec, setting overflow-x to a non-visible value promotes
        overflow-y from `visible` to `auto`, which gave us a stray vertical

--- a/force-app/main/default/lwc/notionWidget/notionWidget.html
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.html
@@ -1,5 +1,11 @@
 <template>
-    <lightning-card title={widgetTitle} icon-name="custom:custom63">
+    <lightning-card>
+        <h2 slot="title" class="slds-card__header-title">
+            <span class="slds-icon_container slds-m-right_x-small notion-card-icon">
+                <img src={notionLogoUrl} alt="Notion" class="notion-card-icon-img"/>
+            </span>
+            <span class="slds-truncate" title={widgetTitle}>{widgetTitle}</span>
+        </h2>
         <div slot="actions" class="slds-grid slds-grid_vertical-align-center">
             <lightning-button-icon
                 icon-name="utility:refresh"

--- a/force-app/main/default/lwc/notionWidget/notionWidget.js
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.js
@@ -1,5 +1,6 @@
 import { LightningElement, api, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import notionLogo from '@salesforce/resourceUrl/NotionLogo';
 import getWidgetData from '@salesforce/apex/NotionWidgetController.getWidgetData';
 import getWidgetConfiguration from '@salesforce/apex/NotionWidgetController.getWidgetConfiguration';
 import createNotionPage from '@salesforce/apex/NotionWidgetController.createNotionPage';
@@ -413,6 +414,10 @@ export default class NotionWidget extends LightningElement {
 
     get widgetTitle() {
         return this.widgetConfig?.label || '';
+    }
+
+    get notionLogoUrl() {
+        return notionLogo;
     }
 
     get headerColumns() {

--- a/force-app/main/default/lwc/notionWidget/notionWidget.svg
+++ b/force-app/main/default/lwc/notionWidget/notionWidget.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="3" y="3" width="94" height="94" rx="16" fill="#FFFFFF" stroke="#000000" stroke-width="6"/>
+  <path d="M25 25 V75 H38 V45 L62 75 H75 V25 H62 V55 L38 25 Z" fill="#000000"/>
+</svg>

--- a/force-app/main/default/staticresources/NotionLogo.resource-meta.xml
+++ b/force-app/main/default/staticresources/NotionLogo.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Public</cacheControl>
+    <contentType>image/svg+xml</contentType>
+</StaticResource>

--- a/force-app/main/default/staticresources/NotionLogo.svg
+++ b/force-app/main/default/staticresources/NotionLogo.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="3" y="3" width="94" height="94" rx="16" fill="#FFFFFF" stroke="#000000" stroke-width="6"/>
+  <path d="M25 25 V75 H38 V45 L62 75 H75 V25 H62 V55 L38 25 Z" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary

Both `notionWidget` and `notionNavigation` shipped with SLDS placeholder custom icons (`custom:custom19` / `custom:custom63`) for both the runtime card header and the Lightning App Builder palette tile. Those defaults don't communicate that these components surface Notion data — the palette in particular reads as generic Salesforce custom items.

Replace with a hand-drawn Notion-style mark (favicon style: black \"N\" letterform on a white rounded square with a heavy black outline). The mark ships in two places:

- **`staticresources/NotionLogo.svg`** — referenced from the runtime card header via a custom `<h2 slot=\"title\">` slot. `lightning-card`'s built-in `icon-name` only accepts SLDS icon names, so the title slot is the supported way to put a brand mark in its place.
- **`<bundle>.svg`** in each LWC folder — picked up by the Lightning App Builder palette so the components appear with the Notion mark in the component list as well.

Adds a small CSS rule per bundle to size the inline `<img>` at the same `1.5rem` the default SLDS card icon occupies, so vertical alignment with the title text is preserved.

## Test plan

- [x] Hard-reload scratch org with a record page hosting a Notion Widget — both widget cards now show the Notion-style mark in their header next to the title
- [x] The mark renders cleanly at the small (~1.5rem) size used in the card header
- [x] No regressions in widget body / table rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)