### PR TITLE
feat: Replace nav sync checkbox with split-button dropdown

### DIFF
--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.html
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.html
@@ -22,26 +22,35 @@
                     </div>
                 </template>
                 <template lwc:else>
-                    <template if:true={showSyncCheckbox}>
-                        <div class="slds-p-bottom_small">
-                            <lightning-input
-                                type="checkbox"
-                                label="Sync record before navigating"
-                                checked={checkboxInitialChecked}
-                                onchange={handleSyncCheckbox}
-                                disabled={syncing}>
-                            </lightning-input>
-                        </div>
-                    </template>
                     <template if:true={showNavigateAction}>
                         <div class={actionContainerClass}>
                             <template if:true={showButtonWithLabel}>
-                                <lightning-button
-                                    label={actionLabel}
-                                    icon-name="utility:new_window"
-                                    onclick={navigateToNotion}
-                                    disabled={syncing}>
-                                </lightning-button>
+                                <template if:true={showSyncDropdown}>
+                                    <lightning-button-group>
+                                        <lightning-button
+                                            label={actionLabel}
+                                            icon-name="utility:new_window"
+                                            onclick={navigateToNotion}
+                                            disabled={syncing}>
+                                        </lightning-button>
+                                        <lightning-button-menu
+                                            icon-name="utility:down"
+                                            alternative-text="More navigate options"
+                                            menu-alignment="auto"
+                                            onselect={handleSyncMenuSelect}
+                                            disabled={syncing}>
+                                            <lightning-menu-item value="alternate" label={alternateSyncLabel}></lightning-menu-item>
+                                        </lightning-button-menu>
+                                    </lightning-button-group>
+                                </template>
+                                <template if:false={showSyncDropdown}>
+                                    <lightning-button
+                                        label={actionLabel}
+                                        icon-name="utility:new_window"
+                                        onclick={navigateToNotion}
+                                        disabled={syncing}>
+                                    </lightning-button>
+                                </template>
                             </template>
                             <template if:true={showButtonIconOnly}>
                                 <lightning-button-icon
@@ -110,25 +119,34 @@
                 </span>
             </template>
             <template lwc:else>
-                <template if:true={showSyncCheckbox}>
-                    <div class="slds-p-bottom_x-small">
-                        <lightning-input
-                            type="checkbox"
-                            label="Sync record before navigating"
-                            checked={checkboxInitialChecked}
-                            onchange={handleSyncCheckbox}
-                            disabled={syncing}>
-                        </lightning-input>
-                    </div>
-                </template>
                 <template if:true={showNavigateAction}>
                     <template if:true={showButtonWithLabel}>
-                        <lightning-button
-                            label={actionLabel}
-                            icon-name="utility:new_window"
-                            onclick={navigateToNotion}
-                            disabled={syncing}>
-                        </lightning-button>
+                        <template if:true={showSyncDropdown}>
+                            <lightning-button-group>
+                                <lightning-button
+                                    label={actionLabel}
+                                    icon-name="utility:new_window"
+                                    onclick={navigateToNotion}
+                                    disabled={syncing}>
+                                </lightning-button>
+                                <lightning-button-menu
+                                    icon-name="utility:down"
+                                    alternative-text="More navigate options"
+                                    menu-alignment="auto"
+                                    onselect={handleSyncMenuSelect}
+                                    disabled={syncing}>
+                                    <lightning-menu-item value="alternate" label={alternateSyncLabel}></lightning-menu-item>
+                                </lightning-button-menu>
+                            </lightning-button-group>
+                        </template>
+                        <template if:false={showSyncDropdown}>
+                            <lightning-button
+                                label={actionLabel}
+                                icon-name="utility:new_window"
+                                onclick={navigateToNotion}
+                                disabled={syncing}>
+                            </lightning-button>
+                        </template>
                     </template>
                     <template if:true={showButtonIconOnly}>
                         <lightning-button-icon

--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.js
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.js
@@ -36,12 +36,6 @@ export default class NotionNavigation extends LightningElement {
     error = null;
     hasCheckedAutoRedirect = false;
 
-    // Runtime state for the optional sync checkbox. Initialised from
-    // `syncBeforeNavigate` when the component mounts and after the page
-    // loads, so the checkbox's default position follows the designer's
-    // configured default.
-    _syncBeforeNavRuntime = null;
-
     connectedCallback() {
         this.checkNotionPage();
     }
@@ -74,20 +68,37 @@ export default class NotionNavigation extends LightningElement {
         this.error = null;
     }
 
-    handleSyncCheckbox(event) {
-        this._syncBeforeNavRuntime = event.target.checked;
-    }
-
     async navigateToNotion(event) {
         // Stop the anchor's default `#` navigation when in link style.
         if (event && event.preventDefault) {
             event.preventDefault();
         }
         try {
-            if (this.effectiveSyncBeforeNavigate) {
+            // The main action follows the designer-configured default.
+            if (this.syncBeforeNavigate) {
                 await this.syncAndNavigate();
             } else {
                 this.redirectToNotion();
+            }
+        } catch (e) {
+            this.showError(e);
+        }
+    }
+
+    // Dropdown menu attached to the main navigate button. The single
+    // entry in the menu is always the *opposite* action — if the
+    // designer-configured default is "navigate only", the menu offers
+    // "Sync, then open"; if the default is "Sync, then open", the menu
+    // offers "Open without syncing".
+    async handleSyncMenuSelect(event) {
+        if (event?.detail?.value !== 'alternate') return;
+        try {
+            if (this.syncBeforeNavigate) {
+                // Default is sync — alternate is plain navigate.
+                this.redirectToNotion();
+            } else {
+                // Default is plain navigate — alternate is sync-then-navigate.
+                await this.syncAndNavigate();
             }
         } catch (e) {
             this.showError(e);
@@ -208,34 +219,27 @@ export default class NotionNavigation extends LightningElement {
         return this.showSyncOption !== false;
     }
 
-    // When the runtime checkbox is enabled, surface it next to the
-    // navigate action so the user can opt in/out per-click. Hidden in
-    // link style (links don't pair well with a stacked checkbox above
-    // them) and only shown once a Notion page is known to exist.
-    get showSyncCheckbox() {
+    // When the sync option is enabled, the navigate button gets a
+    // chevron dropdown next to it offering the opposite-of-default
+    // action. Hidden in link style and icon-only button style (neither
+    // layout pairs naturally with a chevron dropdown), and only when a
+    // Notion page is known to exist.
+    get showSyncDropdown() {
         return this.syncOptionVisible
-            && this.isButtonStyle
+            && this.showButtonWithLabel
             && this.showNavigateAction;
     }
 
-    // Effective "do sync" decision used by navigateToNotion. When the
-    // checkbox is rendered we follow the user's current selection (or
-    // the designer-configured default if the user hasn't touched it).
-    // When the checkbox is suppressed (showSyncOption=false), we obey
-    // the designer-configured flag directly.
-    get effectiveSyncBeforeNavigate() {
-        if (this.showSyncCheckbox) {
-            return this._syncBeforeNavRuntime !== null
-                ? this._syncBeforeNavRuntime
-                : !!this.syncBeforeNavigate;
-        }
-        return !!this.syncBeforeNavigate;
-    }
-
-    get checkboxInitialChecked() {
-        return this._syncBeforeNavRuntime !== null
-            ? this._syncBeforeNavRuntime
-            : !!this.syncBeforeNavigate;
+    // Label shown on the dropdown menu item — always the alternate of
+    // the designer-configured default. e.g. when `syncBeforeNavigate`
+    // is true the main button syncs and the dropdown says
+    // "<actionLabel> (Without Sync)"; when false it's
+    // "<actionLabel> (With Sync)".
+    get alternateSyncLabel() {
+        const suffix = this.syncBeforeNavigate
+            ? '(Without Sync)'
+            : '(With Sync)';
+        return `${this.actionLabel} ${suffix}`;
     }
 
     get isLinkStyle() {


### PR DESCRIPTION
## Summary

Showing the sync runtime option as a checkbox stacked above the navigate button felt heavy for an option invoked at most once per click. Replace it with a split-button dropdown on the main navigate button.

Mechanics:

- **Main button**: keeps the designer-configured default. `syncBeforeNavigate=false` → plain open; `true` → sync-then-open.
- **Chevron dropdown**: shows the *opposite* action, labelled \`<actionLabel> (With Sync)\` or \`<actionLabel> (Without Sync)\` — the user can pick the alternate without first toggling state.
- Dropdown only appears alongside the labelled-button variant. Link style and icon-only button style don't pair naturally with a chevron, and the link variant should read as a single inline affordance.
- \`showSyncOption=false\` still suppresses the dropdown entirely so the page author can lock in the default.

Drops the runtime checkbox state (\`_syncBeforeNavRuntime\`, \`handleSyncCheckbox\`, \`effectiveSyncBeforeNavigate\`, \`checkboxInitialChecked\`). \`showSyncCheckbox\` getter renamed to \`showSyncDropdown\` to match.

## Test plan

- [x] Default widget (syncBeforeNavigate=false): main button \"Open in Notion\" navigates only; dropdown shows \"Open in Notion (With Sync)\" and runs sync-then-open
- [x] Designer-sync-on variant (syncBeforeNavigate=true, showSyncOption=true): main button syncs and opens; dropdown shows \"Open in Notion (Without Sync)\" and just opens
- [x] showSyncOption=false: no chevron, just the plain button
- [x] Link / icon-only button styles: no dropdown rendered
- [x] Existing visual defaults preserved for cases that don't enable sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)