### PR TITLE
docs: Add admin setup guide and refresh Admin UI / README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Salesforce-native integration tool that synchronizes Salesforce data to Notion
 
 - 🔄 Real-time synchronization via Flow triggers
 - 🔗 Preserves Salesforce object relationships as Notion relations
+- 📊 Embeddable **Notion Widget** Lightning component that surfaces Notion database rows on record, app, and home pages — with optional related-list behavior
+- 🧭 **Notion Navigation** component that opens a record's Notion page from Salesforce
 - ⚡ Asynchronous processing using Queueable Apex
 - 🛠️ Configuration-driven through Custom Metadata Types
 - 🔒 Secure API integration with Named Credentials
@@ -24,82 +26,16 @@ The synchronous approach maintains user context throughout the process, ensuring
 
 ## Setup
 
-### Prerequisites
+The full installation and configuration walkthrough for administrators — package install, Notion integration, credentials, Sync mappings, Widget configuration, Flow setup, and verification — lives in **[docs/SETUP_GUIDE.md](docs/SETUP_GUIDE.md)**.
 
-1. Salesforce org with API access
-2. Notion workspace with API access
-3. Salesforce CLI (sfdx) installed
+Quick links by topic:
 
-### Installation
-
-1. Clone the repository:
-```bash
-git clone https://github.com/stomita/notion-salesforce-sync.git
-cd notion-salesforce-sync
-```
-
-2. Deploy to your Salesforce org:
-```bash
-sf project deploy start --source-dir force-app/main
-```
-
-Note: Use `sf` (Salesforce CLI v2) instead of `sfdx` for all commands.
-
-3. Configure Named Credentials for Notion API access:
-
-   a. **Get your Notion API token:**
-   - Go to [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
-   - Click "New integration"
-   - Give it a name (e.g., "Salesforce Sync")
-   - Select the workspace you want to connect
-   - Click "Submit"
-   - Copy the "Internal Integration Token" (starts with `ntn_` or `secret_`)
-
-   b. **Configure API Key in Salesforce:**
-   
-   The External Credential and Named Principal are already deployed with the metadata. You only need to add your API key:
-   
-   - Go to Setup → Security → Named Credentials
-   - Click on "External Credentials" tab
-   - Find "Notion Credential" (already deployed)
-   - Click on "NotionIntegration" principal (already created as Named Principal for org-wide access)
-   - Under Authentication Parameters, click "New"
-   - Add parameter:
-     - Parameter Name: `SecretKey`
-     - Parameter Value: Your Notion API token (the one you copied from step a)
-   - Save
-
-   c. **Assign Permission Set (Required):**
-   - Go to Setup → Permission Sets
-   - Find "Notion Integration User" (already deployed)
-   - Click "Manage Assignments" → "Add Assignment"
-   - Select users who will trigger syncs
-   - Save
-   - This permission set grants access to the Named Principal credential
-
-   d. **Grant integration access to your Notion databases:**
-   - In Notion, go to each database you want to sync
-   - Click the "..." menu → "Add connections"
-   - Select your integration and click "Confirm"
-
-
-4. Set up Custom Metadata records for your sync configuration
-
-## Configuration
-
-### Custom Metadata Types
-
-- **NotionSyncObject__mdt**: Define which Salesforce objects to sync
-- **NotionSyncField__mdt**: Map Salesforce fields to Notion properties
-- **NotionDatabase__mdt**: Store Notion database configurations
-- **NotionRelation__mdt**: Define relationship mappings
-
-### Flow Setup
-
-1. Create a Record-Triggered Flow for each object you want to sync
-2. Configure triggers for Insert, Update, and Delete
-3. Add Action to call the NotionSyncInvocable Apex method
-4. Map the required parameters: recordId, objectType, and operationType
+- **Install + first-time setup**: [docs/SETUP_GUIDE.md](docs/SETUP_GUIDE.md)
+- **Admin UI reference (Sync and Widget Designer)**: [docs/ADMIN_UI_USAGE.md](docs/ADMIN_UI_USAGE.md)
+- **Flow trigger configuration**: [docs/FLOW_CONFIGURATION.md](docs/FLOW_CONFIGURATION.md)
+- **Bulk / large data behavior**: [docs/LARGE_DATA_SYNC.md](docs/LARGE_DATA_SYNC.md)
+- **Developer scratch org setup**: [docs/SCRATCH_ORG_SETUP.md](docs/SCRATCH_ORG_SETUP.md)
+- **Packaging (2GP)**: [docs/PACKAGING.md](docs/PACKAGING.md)
 
 ## Development
 
@@ -218,7 +154,7 @@ This error occurs when the user cannot access the Named Credential.
 This indicates the Named Principal credential is not configured.
 
 **Solution:**
-1. The Named Principal should already exist - just add your API key as described in section 3.b
+1. The Named Principal should already exist — add your API key as described in [SETUP_GUIDE.md Step 3.1](docs/SETUP_GUIDE.md#31-register-your-notion-api-key)
 2. Ensure the `SecretKey` parameter contains your valid Notion API token
 3. Verify the "Notion Integration User" permission set is assigned to your user
 

--- a/docs/ADMIN_UI_USAGE.md
+++ b/docs/ADMIN_UI_USAGE.md
@@ -2,216 +2,207 @@
 
 ## Overview
 
-The Notion Sync Admin UI is a Lightning Web Component that allows Salesforce administrators to configure synchronization mappings between Salesforce objects and Notion databases without manually editing custom metadata records.
+The Notion Sync Admin UI is a Lightning Web Component that lets Salesforce administrators configure two features of the package without editing custom metadata directly:
 
-## Setup Instructions
+- **Sync**: map Salesforce objects and fields to Notion databases.
+- **Widgets**: configure Notion-database-backed widgets that can be embedded on Lightning pages.
 
-### 1. Deploy the Components
+Both features share the same Admin tab inside the **Notion Sync** app, split into sub-tabs.
 
-Deploy all the new components to your Salesforce org:
+> For end-to-end installation and first-time setup, see [SETUP_GUIDE.md](./SETUP_GUIDE.md). This document is the reference for what each control in the Admin UI does.
 
-```bash
-sf project deploy start --source-dir force-app
-```
+## Accessing the Admin UI
 
-### 2. Access the Notion Sync App
+1. Click the App Launcher (9-dot grid icon).
+2. Search for **Notion Sync** and open the app.
+3. The app includes two top-level tabs:
+   - **Notion Sync Admin** — main configuration interface (Sync / Widgets / Settings sub-tabs).
+   - **Notion Sync Log** — recent sync attempts and their status.
 
-The admin UI is available through a dedicated Lightning App:
+To expose the same tabs in another app, edit it in Setup → **App Manager** → **Navigation Items** and add `Notion Sync Admin` and `Notion Sync Log`.
 
-1. Click the App Launcher (9-dot grid icon)
-2. Search for "Notion Sync"
-3. Click on the Notion Sync app
-4. The app includes two tabs:
-   - **Notion Sync Admin**: Main configuration interface
-   - **Notion Sync Log**: View sync operation history
+## Permission Sets
 
-Alternative method - Add to existing app:
-1. Go to Setup → App Manager
-2. Find your preferred app and click Edit
-3. Select Navigation Items
-4. Add "Notion Sync Admin" and "Notion Sync Log" tabs
-5. Save the changes
+The package ships with three permission sets. Assign each to the users who need it.
 
-### 3. Grant Permissions
-
-The Notion Sync Admin UI requires specific permissions. There are two permission sets:
-
-#### Notion Sync Administrator Permission Set
-This is the main permission set for admin UI access. Assign this to users who need to:
-- Configure sync mappings
-- Browse Notion databases
-- Manage field mappings
-- Test connections
+| Permission Set | Label | Who needs it |
+|---|---|---|
+| `Notion_Sync_Admin` | Notion Sync Administrator | Admins configuring sync mappings and widgets. |
+| `Notion_Integration_User` | Notion Integration User | Users whose record changes should trigger a sync via Flow. |
+| `Notion_Widget_User` | Notion Widget User | End users who only view embedded widgets on Lightning pages. |
 
 To assign:
-1. Go to Setup → Users → Permission Sets
-2. Find "Notion Sync Administrator"
-3. Click on Manage Assignments
-4. Add users who need admin access
 
-This permission set includes:
-- Custom permission: Notion_Sync_Admin
-- Access to Notion API credentials
-- Custom metadata type access
-- Required user permissions (CustomizeApplication, ModifyMetadata)
-- Read-only access to sync logs
+1. Setup → **Permission Sets** → click the permission set name.
+2. **Manage Assignments** → **Add Assignment** → pick users → **Assign**.
 
-#### Notion Integration User Permission Set
-This is for users who only need to trigger syncs via Flow. They don't need admin access.
+The Notion Sync Administrator set includes the custom permission `Notion_Sync_Admin`, access to the Notion External Credential, read access to all custom metadata types in this package, the user permissions required to deploy metadata (Customize Application, Modify Metadata), and read-only access to sync logs.
 
-## Using the Admin UI
+A user can hold more than one set — an admin who also edits records and triggers syncs typically needs both Administrator and Integration User.
 
-### Main View - Sync Configurations
+## Admin UI Layout
 
-When you open the Notion Sync Admin, you'll see:
+The **Notion Sync Admin** tab is organized into three sub-tabs:
 
-1. **Summary Statistics**: 
-   - Configured Objects count
-   - Active Syncs count
-   - Total Field Mappings count
+| Sub-tab | Purpose |
+|---|---|
+| **Sync** | Configure object-to-database mappings, field mappings, and relationships. |
+| **Widgets** | Configure Notion-database-backed widgets that can be embedded on Lightning pages. |
+| **Settings** | Test the Notion connection and view package-level options. |
 
-2. **Configured Objects Table**:
-   - Lists all existing sync configurations
-   - Shows Salesforce object name and API name
-   - Displays Notion database ID (database names coming soon)
-   - Shows Active/Inactive status
-   - Field mappings and relationships count
-   - Edit button for each configuration
+The **Test Connection** action available at the top of the page works in any sub-tab and verifies Named Credential access plus database visibility.
 
-3. **New Sync Configuration Button**: Click to create a new object mapping
+## Sync Sub-tab
 
-### Creating a New Configuration
+### Sync configuration list
 
-1. **Click "New Sync Configuration"**
-2. **Select Salesforce Object**: Choose from the dropdown list
-3. **Configure Basic Settings**:
-   - Set Active status (enabled by default)
-   - Click "Browse Databases" to select a Notion database
-   - Set the Salesforce ID property name (default: "Salesforce_ID")
-4. **Save Initial Configuration**: You can save now and add field mappings later
+The Sync sub-tab shows the existing sync configurations along with summary statistics: configured objects, active syncs, and total field mappings. Each row shows the Salesforce object, the linked Notion database, active state, and counts of field and relationship mappings, with an **Edit** action per row.
 
-### Editing an Existing Configuration
+Click **New Sync Configuration** to create a new mapping.
 
-1. **Click "Edit"** on any configuration in the main table
-2. **Basic Configuration Section**:
-   - Toggle Active status
-   - Change Notion database if needed
-   - Update Salesforce ID property name
+### Creating a sync configuration
 
-3. **Field Mappings Section**:
-   - View existing field mappings
-   - Add new mappings with the field mapping component
-   - Auto-detection suggests compatible Notion property types
-   - Long text fields can be mapped to page body content
+1. Click **New Sync Configuration**.
+2. Pick a Salesforce object from the dropdown.
+3. Toggle **Active** (enabled by default).
+4. Click **Browse Databases** to pick the target Notion database. The database must have already been shared with the integration in Notion.
+5. Pick the **Salesforce ID Property Name** — the Notion text property where the package will store the Salesforce record ID. The property must already exist on the Notion database, so add it first if it's missing.
+6. Save. You can return later to add field mappings.
 
-4. **Relationship Mappings Section**:
-   - Configure parent-child relationships
-   - Map lookup/master-detail fields to Notion relations
+### Editing a sync configuration
 
-5. **Action Buttons**:
-   - **Cancel**: Discard changes (with confirmation if unsaved)
-   - **Test Connection**: Verify Notion API connectivity
-   - **Save**: Deploy configuration to metadata
+Opening an existing configuration exposes three sections:
 
-### Database Browser Modal
+- **Basic Configuration** — toggle active state, change the Notion database, or change the Salesforce ID property name.
+- **Field Mappings** — add mappings between Salesforce fields and Notion properties. The UI auto-suggests a compatible Notion property type per Salesforce field type (see [Auto Type Detection](#auto-type-detection)). Long text areas can be flagged as page body content instead of a property.
+- **Relationship Mappings** — map Salesforce lookup or master-detail fields to Notion relation properties so parent–child structure is preserved on the Notion side.
 
-When clicking "Browse Databases":
-- Modal window shows all accessible Notion databases
-- Search by database name or ID
-- Click to select a database
-- Shows database properties and their types
+Action buttons:
 
-### Navigation
+- **Cancel** — discard changes (with confirmation if there are unsaved edits).
+- **Test Connection** — verify Notion API connectivity.
+- **Save** — deploy the configuration as custom metadata.
 
-- **Back Button**: Return to main configuration list
-- **Tab Navigation**: Switch between Notion Sync Admin and Notion Sync Log
-- **App Launcher**: Access from the 9-dot grid menu
+### Database Browser modal
 
-## Features
+Clicking **Browse Databases** opens a modal listing every Notion database the integration can see. Search by database name or ID, and select one to populate the field. The modal also previews the database's properties and their types.
 
 ### Auto Type Detection
 
-The UI automatically suggests Notion property types based on Salesforce field types:
+The UI suggests Notion property types from the chosen Salesforce field's type:
 
 - STRING → rich_text
 - EMAIL → email
-- NUMBER/CURRENCY → number
-- DATE/DATETIME → date
+- NUMBER / CURRENCY → number
+- DATE / DATETIME → date
 - BOOLEAN → checkbox
 - PICKLIST → select
 - REFERENCE → relation
 
-### Field Mapping
+You can override the suggestion if your Notion schema differs.
 
-- Map any Salesforce field to any Notion property
-- Long text areas can be mapped to page body content
-- Property types can be manually adjusted if needed
+### Sync best practices
 
-### Test Connection
+- Always run **Test Connection** before saving.
+- Ensure at least one Salesforce field maps to a Notion **title** property — every page needs a title.
+- Keep the Salesforce ID property pointing to a text property used only by the package.
+- Start with a handful of fields, verify the sync end-to-end, then expand.
 
-Use the "Test Connection" button to verify:
-- Notion API connectivity
-- Database accessibility
-- Named Credential configuration
+## Widgets Sub-tab
 
-### Notion Sync Log Tab
+The Widgets sub-tab lets administrators create and manage widgets backed by `NotionWidget__mdt`. Each widget can be embedded into a Lightning page using the **Notion Widget** Lightning component in App Builder.
 
-The Notion Sync Log tab provides visibility into sync operations:
+### Widget list
 
-1. **List View**: Shows recent sync attempts sorted by creation date (newest first)
-2. **Record Details**: Click on any log entry to see:
-   - Record ID and Object Type
-   - Operation Type (CREATE/UPDATE/DELETE)
-   - Status (Success/Failed/Retrying)
-   - Notion Page ID (if successful)
-   - Error Message (if failed)
-   - Timestamp
+The list shows the developer name, target Notion database, optional context object, active status, and column/filter counts for every configured widget. Use **Edit** to open a widget, or the trash icon to delete it. Click **New Widget** to create one.
 
-The list view uses a formula field to enable descending date sorting, showing the most recent sync operations first.
+### Creating a widget
 
-## Permission Details
+1. Click **New Widget**.
+2. Enter a **Label** and **Developer Name**. The developer name is what you'll pick in Lightning App Builder.
+3. **Notion Database** — click **Browse** and select the source database. The integration must have access to it (Notion `•••` → **Connections**).
+4. **Context Object** *(optional)* — the Salesforce object the widget will live on (for record pages). Setting this lets the widget filter to pages related to that record.
+5. **Context Relation Property** *(optional)* — the name of the Notion relation property on the target database that links to the context record's Notion page. When set, the widget behaves like a Salesforce related list:
+   - rows are filtered to those whose relation includes the context Notion page;
+   - clicking **New** opens a draft modal with that relation pre-populated.
+6. **Default Sort Property** / **Default Sort Direction** *(optional)* — initial sort applied to the table.
+7. **Page Size** — number of rows per page (default 25, max 100).
+8. **Show New Button** — toggle the inline "New" button that creates Notion pages straight from the widget.
+9. **Is Active** — only active widgets are selectable in App Builder.
+10. **Columns** — pick which Notion properties to display, set their order, and choose their column widths. Reordering persists on save.
+11. **Filters** — add fixed filters (Notion property comparisons) layered on top of the context filter, if any.
+12. Save.
 
-When users don't have the required permission set, they will see a clear message in the UI:
-- "Access Denied" screen with graphical illustration
-- Clear message: "You don't have permission to access the Notion Sync Admin interface"
-- Instructions to contact system administrator
-- Specific request for "Notion Sync Administrator" permission set
+### Embedding a widget on a Lightning page
 
-The permission set checks are performed on all Apex methods to ensure security using the custom permission `Notion_Sync_Admin`.
+1. Open the target page in App Builder (record page, app page, or home page).
+2. From the **Custom** component panel, drag **Notion Widget** onto the page.
+3. With the widget selected, set the **Widget Configuration** property to the developer name of the widget you created. The field is a picklist sourced from active `NotionWidget__mdt` records.
+4. Save and activate the page.
+
+### Widget best practices
+
+- Use a clear, descriptive developer name — admins editing Lightning pages see this in the picklist.
+- For context-bound (related-list-style) widgets, make sure the parent record already has a synced Notion page; otherwise the widget has nothing to anchor against.
+- If the picklist in App Builder is empty, confirm at least one widget has **Is Active = true**.
+
+## Notion Navigation Component
+
+In addition to the Widget, the package ships a **Notion Navigation** Lightning component that opens a record's Notion page directly. It supports record pages and Flow screens and is configured per-instance in App Builder / Flow Builder — not in the Admin UI.
+
+Notable properties:
+
+- **Card Title** / **Show Title** — wrap the action in a Lightning card with a Notion-branded header, or render the action bare.
+- **Navigation Style** — `button` (labelled button) or `link` (inline text link). With `button` you can also hide the label to get an icon-only button.
+- **Action Label** / **Show Action Label** / **Action Alignment** — text shown on the button or link, whether to show it, and its alignment in the card.
+- **Sync Before Navigate** — default sync behavior for the main click: when on, the package syncs the record to Notion before opening; when off, it opens the existing page directly.
+- **Show Sync Option** — when on (and the variant is the labelled button), a chevron dropdown is attached next to the main button. The dropdown offers the **opposite** sync mode (e.g., *Open in Notion (With Sync)* when the default is without-sync), so end users can pick the alternate behavior per click without first toggling state. Turn this off to lock in the designer default and hide the alternate entirely.
+
+The split-button dropdown is only shown alongside the labelled-button variant; the link style and icon-only button render the main action alone.
+
+## Notion Sync Log Tab
+
+The **Notion Sync Log** tab shows recent sync attempts sorted newest first. Click any log row to see:
+
+- Record ID and Object Type
+- Operation Type (CREATE / UPDATE / DELETE)
+- Status (Success / Failed / Retrying)
+- Notion Page ID (on success)
+- Error Message (on failure)
+- Timestamp
+
+The list view uses a formula field to enable descending date sorting.
+
+## Permission Failures
+
+If a user without `Notion_Sync_Admin` opens the Admin UI, they see an "Access Denied" screen instructing them to contact their administrator and request the **Notion Sync Administrator** permission set. The same check is enforced on every Apex method behind the UI using the `Notion_Sync_Admin` custom permission, so the UI cannot be bypassed.
 
 ## Troubleshooting
 
-### Cannot See Notion Databases
+### Cannot see Notion databases
 
-1. Verify Named Credential is configured correctly
-2. Check that the Notion API token has access to databases
-3. Use "Test Connection" to diagnose issues
+- Confirm the Named Credential is configured with a valid API token.
+- Confirm the integration is connected to the database (Notion `•••` → **Connections**).
+- Run **Test Connection** for a precise error.
 
-### Metadata Save Fails
+### Metadata save fails
 
-1. Ensure user has Customize Application permission
-2. Check for duplicate developer names in metadata
-3. Review debug logs for specific errors
+- The user needs Customize Application + Modify Metadata permissions (included in the Notion Sync Administrator set).
+- Developer names must be unique — pick a different one if the save reports a conflict.
+- Check the debug log if the error is unclear.
 
-### Field Mappings Not Working
+### Field mappings don't sync
 
-1. Verify Notion property names match exactly
-2. Ensure property types are compatible
-3. Check that Salesforce fields are accessible
+- Notion property names are case- and whitespace-sensitive — verify they match exactly.
+- Confirm Notion property types are compatible with the Salesforce field types.
+- Confirm field-level security allows the integration user to read the field.
 
-## Best Practices
+### Widget config picklist is empty in App Builder
 
-1. **Test First**: Always test connection before saving
-2. **Map Required Fields**: Ensure all required Notion properties are mapped
-3. **Use Title Property**: At least one field should map to a "title" property
-4. **Unique Identifiers**: Keep the Salesforce ID property for sync tracking
-5. **Start Small**: Begin with a few fields and expand gradually
+- At least one widget must be **Is Active = true**.
+- Re-saving the widget refreshes the picklist if the change isn't visible yet.
 
-## Next Steps
+## Reference
 
-After configuring sync mappings:
-
-1. Set up Flow triggers for the objects (see FLOW_CONFIGURATION.md)
-2. Test sync with a few records
-3. Monitor sync logs for any issues
-4. Scale up to production data volumes
+- [SETUP_GUIDE.md](./SETUP_GUIDE.md) — end-to-end install and configuration walkthrough.
+- [FLOW_CONFIGURATION.md](./FLOW_CONFIGURATION.md) — per-object Flow setup for triggering syncs.

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1,0 +1,234 @@
+# Setup Guide
+
+This guide walks a Salesforce administrator through installing the **Notion Salesforce Sync** package and configuring it for synchronization, the Notion Widget, or both.
+
+The shared steps (1–3) are required for any use of the package. After Step 3, jump to the path you need:
+
+- **Path A — Configure Sync**: push Salesforce records to Notion databases via Flow triggers.
+- **Path B — Configure a Widget**: embed a Notion database view inside a Lightning page.
+
+---
+
+## Prerequisites
+
+- A Salesforce org you have **System Administrator** access to (Production, Sandbox, or Developer Edition).
+- A Notion workspace where you can create an **integration** and grant it access to databases.
+- A modern browser. CLI access is optional — every step below has a UI alternative.
+
+---
+
+## Step 1 — Install the package
+
+The package is distributed as a managed 2GP under the `notionsync` namespace.
+
+### Install URL (latest released version)
+
+Open the following URL while logged into your target org. Choose **Install for Admins Only** unless you have a specific reason to expand access.
+
+```
+https://login.salesforce.com/packaging/installPackage.apexp?p0=04tgL000000GJhpQAG
+```
+
+For a Sandbox, replace `login.salesforce.com` with `test.salesforce.com`.
+
+### CLI alternative
+
+```bash
+sf package install \
+  --package 04tgL000000GJhpQAG \
+  --target-org <your-org-alias> \
+  --wait 20
+```
+
+After installation, you should see the **Notion Sync** app available in the App Launcher.
+
+> Looking for a different version? Run `sf package version list --packages 0HogL0000000FVJSA2 --target-dev-hub <devhub> --released` to see all releases.
+
+---
+
+## Step 2 — Prepare Notion
+
+### 2.1 Create an internal integration
+
+1. Sign in to Notion as a workspace owner and open <https://www.notion.so/my-integrations>.
+2. Click **New integration**.
+3. Set a name (for example, `Salesforce Sync`) and pick the workspace you want to connect.
+4. Submit and copy the **Internal Integration Token** (starts with `ntn_` or `secret_`). Treat this like a password — you'll register it in Salesforce in Step 3.
+
+### 2.2 Grant the integration access to your databases
+
+For **every** Notion database the package will read or write:
+
+1. Open the database page in Notion.
+2. Click the `•••` menu at the top right → **Connections** → **Add connections**.
+3. Select your integration and click **Confirm**.
+
+### 2.3 Add a Salesforce ID property (Sync only)
+
+If you plan to use Path A (Sync), each Notion database that will receive synced records needs a property to store the Salesforce record ID. The package uses this property to detect existing pages and prevent duplicates.
+
+1. Open the target Notion database.
+2. Add a new property (recommended name: `Salesforce ID`, type: **Text**).
+3. Repeat for every database you'll sync to.
+
+You'll select this property by name when you configure the sync in Step 6.
+
+> Widget-only setups (Path B) don't require this — the widget reads any Notion database your integration can access.
+
+---
+
+## Step 3 — Configure Salesforce credentials and permissions
+
+### 3.1 Register your Notion API key
+
+The package ships with an **External Credential** named `Notion Credential` and a **Named Principal** named `NotionIntegration`. You only need to attach your API token.
+
+1. Setup → **Named Credentials** → **External Credentials** tab → **Notion Credential**.
+2. Under **Principals**, click the row for `NotionIntegration`.
+3. Under **Authentication Parameters**, click **New**.
+4. Add:
+   - **Name**: `SecretKey`
+   - **Value**: the Notion integration token from Step 2.1
+5. Save.
+
+### 3.2 Assign permission sets
+
+The package includes three permission sets. Assign each to the users who need it.
+
+| Permission Set | Label | Who needs it |
+|---|---|---|
+| `Notion_Sync_Admin` | Notion Sync Administrator | Admins who configure mappings, widgets, and credentials via the Admin UI. |
+| `Notion_Integration_User` | Notion Integration User | Any user whose record changes should trigger a sync (i.e., users whose actions fire the Flow). |
+| `Notion_Widget_User` | Notion Widget User | End users who only view embedded Notion widgets on Lightning pages. |
+
+To assign:
+
+1. Setup → **Permission Sets** → click the permission set name.
+2. **Manage Assignments** → **Add Assignment** → select users → **Assign**.
+
+> A user can have multiple permission sets. An admin who also triggers syncs needs both Sync Administrator and Integration User.
+
+### 3.3 Verify the connection
+
+1. Open the App Launcher → **Notion Sync**.
+2. On the **Notion Sync Admin** tab, click **Test Connection** (top-right).
+3. You should see a success message listing accessible databases. If not, see [Troubleshooting](#troubleshooting).
+
+At this point, the package is installed and authenticated. Continue to **Path A**, **Path B**, or both.
+
+---
+
+## Path A — Configure Sync
+
+Goal: have a Salesforce record automatically create, update, or delete a corresponding Notion page.
+
+### A.1 Create a sync configuration
+
+1. Open the **Notion Sync** app → **Notion Sync Admin** tab.
+2. Switch to the **Sync** sub-tab.
+3. Click **New Sync Configuration**.
+4. Pick the Salesforce object (e.g., `Account`).
+5. Click **Browse Databases** and select the Notion database prepared in Step 2.3.
+6. For **Salesforce ID Property Name**, pick the property you added in Step 2.3 (e.g., `Salesforce ID`).
+7. Save.
+
+### A.2 Map fields
+
+In the saved configuration:
+
+1. Open the **Field Mappings** section.
+2. For each Salesforce field, add a mapping to a Notion property. The UI auto-suggests a compatible Notion property type.
+3. Make sure at least one mapping targets a Notion **Title** property.
+4. (Optional) Map a Long Text Area to the page body using the **Body Content** flag.
+5. (Optional) Configure **Relationship Mappings** to translate lookups/master-details into Notion relations between databases.
+6. Save. The UI deploys the change as custom metadata.
+
+For details on the Admin UI, see [Admin UI Usage](./ADMIN_UI_USAGE.md).
+
+### A.3 Create the Flow trigger
+
+The package includes template flows you can copy per object. The full procedure is in [Flow Configuration](./FLOW_CONFIGURATION.md). Summary:
+
+1. Copy `NotionSync_Template_CreateUpdate.flow-meta.xml` and `NotionSync_Template_Delete.flow-meta.xml` and rename them for your object.
+2. Replace `[ObjectApiName]` placeholders with your object's API name (e.g., `Account`).
+3. Deploy the flows and **activate** both in Setup → **Flows**.
+
+### A.4 Verify the sync
+
+1. Create a new record of your synced object (e.g., a new Account).
+2. Open the matching Notion database — the page should appear within a few seconds.
+3. Update the record, then delete it, and confirm Notion reflects each change.
+4. If something is missing, open **Notion Sync Logs** (tab in the Notion Sync app) and check the **Status** and **Error Message** columns.
+
+---
+
+## Path B — Configure a Widget
+
+Goal: embed a list of Notion pages on a Salesforce record, app, or home page. The widget can also act as a related list: filtered to pages that relate to the current Salesforce record's Notion counterpart.
+
+### B.1 Create a widget configuration
+
+1. Open the **Notion Sync** app → **Notion Sync Admin** tab.
+2. Switch to the **Widgets** sub-tab.
+3. Click **New Widget**.
+4. Fill in:
+   - **Label** and **Developer Name** — the developer name is what you'll select in App Builder.
+   - **Notion Database** — click **Browse** and pick the source database.
+   - **Context Object** (optional) — set this if the widget will live on a record page and you want it to filter by the related record's Notion page.
+   - **Context Relation Property** (optional) — name of the Notion relation property used to link to the context record's Notion page. When set, the widget behaves like a related list: rows are filtered, and the **New** button creates pages with this relation pre-filled.
+   - **Default Sort**, **Page Size**, **Show New Button** — optional behavior tweaks.
+5. **Columns** — pick which Notion properties to display and order them.
+6. **Filters** — add optional fixed filters on top of the context filter.
+7. Save.
+
+### B.2 Place the widget on a Lightning page
+
+1. Open the Lightning page where the widget should appear (App Builder → **Edit Page** from the record page, app page, or home page).
+2. From the **Custom** components panel on the left, drag **Notion Widget** onto the canvas.
+3. With the widget selected, set **Widget Configuration** to the developer name from B.1 (the field is a picklist).
+4. Save and activate the page.
+
+### B.3 Verify the widget
+
+1. Open the Lightning page where you placed the widget.
+2. Confirm the widget renders rows from your Notion database. If the widget is context-bound (B.1), only rows that link back to the current record's Notion page should appear.
+3. If a **New** button is shown, clicking it should open a draft modal that pre-fills the relation property.
+
+> **Tip — also for navigation**: the package includes a **Notion Navigation** component (record-page or Flow screen) that opens a record's Notion page directly. The labelled-button variant renders as a split-button with a dropdown that lets the end user pick the opposite sync mode (e.g., *Open in Notion (With Sync)*) on each click. Drag it from the same App Builder panel and configure its label, alignment, default sync behavior, and whether the alternate action is offered in the right pane.
+
+---
+
+## Troubleshooting
+
+### "We couldn't access the credential"
+The current user can't read the Named Credential.
+- Confirm the `SecretKey` parameter is set on the `NotionIntegration` principal (Step 3.1).
+- Assign the **Notion Integration User** permission set to the user triggering the sync (or the **Notion Sync Administrator** set for admin actions).
+
+### "Unauthorized endpoint" or 401 from Notion
+The token is missing, wrong, or revoked.
+- Re-paste the token from <https://www.notion.so/my-integrations>.
+- Confirm the integration still has access to the database (`•••` → **Connections** in Notion).
+
+### Sync doesn't run
+- In Setup → **Flows**, confirm both the CreateUpdate and Delete flows for the object are **Active**.
+- Check **Notion Sync Logs** for failures — the Error Message column tells you whether it failed at validation, mapping, or the Notion API.
+- Confirm the user who edited the record has the **Notion Integration User** permission set.
+
+### Widget shows "Access Denied" or an empty list
+- Assign **Notion Widget User** (or **Notion Sync Administrator**) to the viewer.
+- Confirm the Notion database is shared with the integration (Step 2.2).
+- For context-bound widgets, the current record must already have a synced Notion page so the widget has something to filter against.
+
+### The widget picklist in App Builder is empty
+- At least one widget configuration must have **Is Active = true**.
+- The admin set may need to be re-saved if the metadata was just deployed.
+
+---
+
+## Reference
+
+- [Admin UI Usage](./ADMIN_UI_USAGE.md) — full walkthrough of the Sync configuration UI and Widget Designer.
+- [Flow Configuration](./FLOW_CONFIGURATION.md) — template flows and per-object setup.
+- [Large Data Sync](./LARGE_DATA_SYNC.md) — how the queueable architecture handles bulk loads.
+- [Integration Testing](./INTEGRATION_TESTING.md) — running the end-to-end Notion test suite.

--- a/force-app/main/default/lwc/notionNavigation/notionNavigation.js-meta.xml
+++ b/force-app/main/default/lwc/notionNavigation/notionNavigation.js-meta.xml
@@ -19,8 +19,8 @@
             <property name="actionLabel" type="String" label="Action Label" description="Label shown on the navigate action" default="Open in Notion"/>
             <property name="showActionLabel" type="Boolean" label="Show Action Label" description="Show the action label text. When off, only the icon is shown." default="true"/>
             <property name="actionAlignment" type="String" label="Action Alignment" description="Horizontal alignment of the navigation action" default="left" datasource="left,center,right"/>
-            <property name="syncBeforeNavigate" type="Boolean" label="Sync Before Navigate" description="Sync the record to Notion before navigating. When 'Show Sync Option' is on, this sets the checkbox's initial state." default="false"/>
-            <property name="showSyncOption" type="Boolean" label="Show Sync Option" description="Show a checkbox letting the user opt into syncing before navigating, on each click." default="true"/>
+            <property name="syncBeforeNavigate" type="Boolean" label="Sync Before Navigate" description="Default sync behavior for the main navigate action. When on, the record is synced to Notion before the page opens; when off, the existing page is opened directly. When 'Show Sync Option' is on, the dropdown offers the opposite mode for one-click override." default="false"/>
+            <property name="showSyncOption" type="Boolean" label="Show Sync Option" description="Attach a dropdown next to the main button that lets the user pick the opposite sync mode (with sync / without sync) per click. Only applies to the labelled button variant. Turn off to lock in the designer default." default="true"/>
         </targetConfig>
         <targetConfig targets="lightning__RecordPage">
             <property name="cardTitle" type="String" label="Card Title" description="Title shown in the component header" default="Notion Navigation"/>
@@ -29,8 +29,8 @@
             <property name="actionLabel" type="String" label="Action Label" description="Label shown on the navigate action" default="Open in Notion"/>
             <property name="showActionLabel" type="Boolean" label="Show Action Label" description="Show the action label text. When off, only the icon is shown." default="true"/>
             <property name="actionAlignment" type="String" label="Action Alignment" description="Horizontal alignment of the navigation action" default="left" datasource="left,center,right"/>
-            <property name="syncBeforeNavigate" type="Boolean" label="Sync Before Navigate" description="Sync the record to Notion before navigating. When 'Show Sync Option' is on, this sets the checkbox's initial state." default="false"/>
-            <property name="showSyncOption" type="Boolean" label="Show Sync Option" description="Show a checkbox letting the user opt into syncing before navigating, on each click." default="true"/>
+            <property name="syncBeforeNavigate" type="Boolean" label="Sync Before Navigate" description="Default sync behavior for the main navigate action. When on, the record is synced to Notion before the page opens; when off, the existing page is opened directly. When 'Show Sync Option' is on, the dropdown offers the opposite mode for one-click override." default="false"/>
+            <property name="showSyncOption" type="Boolean" label="Show Sync Option" description="Attach a dropdown next to the main button that lets the user pick the opposite sync mode (with sync / without sync) per click. Only applies to the labelled button variant. Turn off to lock in the designer default." default="true"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
## Summary

- Add `docs/SETUP_GUIDE.md` as the single end-to-end install + configuration walkthrough for Salesforce admins consuming the 2GP managed package (latest released install URL, Notion integration setup, credentials/permission sets, parallel Sync and Widget paths, troubleshooting).
- Refresh `docs/ADMIN_UI_USAGE.md` to match the shipped Admin UI: document the Sync / Widgets / Settings sub-tab layout, add a Widget Designer section covering `NotionWidget__mdt` fields and the App Builder `widgetDeveloperName` picklist, add `Notion_Widget_User` to the permission table, and describe the Notion Navigation split-button dropdown UX.
- Trim `README.md`'s Setup section to a pointer (body lives in `SETUP_GUIDE.md`), mention Widget/Navigation in Features, and fix the broken cross-reference in Troubleshooting that pointed to a "section 3.b" that no longer exists.
- Update the App Builder property descriptions on `notionNavigation` (`syncBeforeNavigate`, `showSyncOption`) in both Flow Screen and Record Page `targetConfig` blocks — they still talked about "the checkbox's initial state" after #107 replaced the runtime checkbox with a split-button dropdown.

## Test plan

- [ ] `docs/SETUP_GUIDE.md` renders cleanly on GitHub (anchors and tables in particular).
- [ ] Cross-doc links resolve: `SETUP_GUIDE.md` ↔ `ADMIN_UI_USAGE.md` ↔ `FLOW_CONFIGURATION.md`, and the README pointers all land on the right files.
- [ ] In a scratch org with the updated metadata, opening the `Notion Navigation` component in Lightning App Builder shows the new descriptions for `syncBeforeNavigate` / `showSyncOption` (no remaining mention of "checkbox").
- [ ] No code paths changed — existing Apex / LWC tests still pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)